### PR TITLE
Add `restrict` keyword. Return ESNOSPC for (smax > dmax) overflow checks.

### DIFF
--- a/include/safe_lib.h
+++ b/include/safe_lib.h
@@ -50,12 +50,12 @@ typedef size_t  rsize_t;
  */
 /* #define RSIZE_MAX (~(rsize_t)0)  - leave here for completeness */
 
-typedef void (*constraint_handler_t) (const char * /* msg */,
-                                      void *       /* ptr */,
-                                      errno_t      /* error */);
+typedef void (*constraint_handler_t) (const char * restrict /* msg */,
+                                      void * restrict       /* ptr */,
+                                      errno_t               /* error */);
 
-extern void abort_handler_s(const char *msg, void *ptr, errno_t error);
-extern void ignore_handler_s(const char *msg, void *ptr, errno_t error);
+extern void abort_handler_s(const char * restrict msg, void * restrict ptr, errno_t error);
+extern void ignore_handler_s(const char * restrict msg, void * restrict ptr, errno_t error);
 
 #define sl_default_handler ignore_handler_s
 

--- a/include/safe_lib_errno.h.in
+++ b/include/safe_lib_errno.h.in
@@ -60,7 +60,7 @@ extern "C" {
 #endif
 
 #ifndef ESLEMAX
-#define ESLEMAX         ( 403 )       /* length exceeds max          */
+#define ESLEMAX         ( 403 )       /* length exceeds RSIZE_MAX    */
 #endif
 
 #ifndef ESOVRLP

--- a/include/safe_lib_errno.h.in
+++ b/include/safe_lib_errno.h.in
@@ -38,7 +38,7 @@ extern "C" {
 #endif
 
 #ifdef __KERNEL__
-# include <linux/errno.h>
+#include <linux/errno.h>
 #else
 @INSERT_ERRNO_H@
 #endif /* __KERNEL__ */

--- a/include/safe_mem_lib.h
+++ b/include/safe_mem_lib.h
@@ -62,8 +62,8 @@ extern errno_t memcmp32_s(const uint32_t *dest, rsize_t dmax,
 
 
 /* copy memory */
-extern errno_t memcpy_s(void *dest, rsize_t dmax,
-                        const void *src, rsize_t slen);
+extern errno_t memcpy_s(void * restrict dest, rsize_t dmax,
+                        const void * restrict src, rsize_t slen);
 
 /* copy uint16_t memory */
 extern errno_t memcpy16_s(uint16_t *dest, rsize_t dmax,

--- a/include/safe_str_lib.h
+++ b/include/safe_str_lib.h
@@ -58,7 +58,7 @@ extern "C" {
 
 /* safe sprintf_s */
 extern int
-sprintf_s(char *dest, rsize_t dmax, const char *fmt, ...);
+sprintf_s(char *restrict dest, rsize_t dmax, const char * restrict fmt, ...);
 
 /* set string constraint handler */
 extern constraint_handler_t
@@ -79,7 +79,7 @@ strcasestr_s(char *dest, rsize_t dmax,
 
 /* string concatenate */
 extern errno_t
-strcat_s(char *dest, rsize_t dmax, const char *src);
+strcat_s(char * restrict dest, rsize_t dmax, const char * restrict src);
 
 
 /* string compare */
@@ -96,7 +96,7 @@ strcmpfld_s(const char *dest, rsize_t dmax,
 
 /* string copy */
 extern errno_t
-strcpy_s(char *dest, rsize_t dmax, const char *src);
+strcpy_s(char * restrict dest, rsize_t dmax, const char * restrict src);
 
 
 /* fixed char array copy */
@@ -189,12 +189,12 @@ strljustify_s(char *dest, rsize_t dmax);
 
 /* fitted string concatenate */
 extern errno_t
-strncat_s(char *dest, rsize_t dmax, const char *src, rsize_t slen);
+strncat_s(char * restrict dest, rsize_t dmax, const char * restrict src, rsize_t slen);
 
 
 /* fitted string copy */
 extern errno_t
-strncpy_s(char *dest, rsize_t dmax, const char *src, rsize_t slen);
+strncpy_s(char * restrict dest, rsize_t dmax, const char * restrict src, rsize_t slen);
 
 
 /* string length */
@@ -246,12 +246,12 @@ strstr_s(char *dest, rsize_t dmax,
 
 /* string tokenizer */
 extern char *
-strtok_s(char *s1, rsize_t *s1max, const char *src, char **ptr);
+strtok_s(char * restrict s1, rsize_t *restrict s1max, const char * restrict src, char ** restrict ptr);
 
 
 /* convert string to lowercase */
 extern errno_t
-strtolowercase_s(char *str, rsize_t slen);
+strtolowercase_s(char * restrict str, rsize_t slen);
 
 
 /* convert string to uppercase */

--- a/src/safeclib/abort_handler_s.c
+++ b/src/safeclib/abort_handler_s.c
@@ -37,7 +37,7 @@
  *
  * SYNOPSIS
  *    #include "safe_lib.h"
- *    void abort_handler_s(const char *msg, void *ptr, errno_t error)
+ *    void abort_handler_s(const char * restrict msg, void * restrict ptr, errno_t error)
  *
  * DESCRIPTION
  *    This function writes a message on the standard error stream in
@@ -65,7 +65,7 @@
  *
  */
 
-void abort_handler_s(const char *msg, void *ptr, errno_t error)
+void abort_handler_s(const char * restrict msg, void * restrict ptr, errno_t error)
 {
 	slprintf("ABORT CONSTRAINT HANDLER: (%u) %s\n", error,
 		 (msg) ? msg : "Null message");

--- a/src/safeclib/ignore_handler_s.c
+++ b/src/safeclib/ignore_handler_s.c
@@ -37,7 +37,7 @@
  *
  * SYNOPSIS
  *    #include "safe_lib.h"
- *    void ignore_handler_s(const char *msg, void *ptr, errno_t error)
+ *    void ignore_handler_s(const char * restrict msg, void * restrict ptr, errno_t error)
  *
  * DESCRIPTION
  *    This function simply returns to the caller.
@@ -62,7 +62,7 @@
  *
  */
 
-void ignore_handler_s(const char *msg, void *ptr, errno_t error)
+void ignore_handler_s(const char * restrict msg, void * restrict ptr, errno_t error)
 {
 
 	sldebug_printf("IGNORE CONSTRAINT HANDLER: (%u) %s\n", error,

--- a/src/safeclib/memcmp16_s.c
+++ b/src/safeclib/memcmp16_s.c
@@ -139,8 +139,8 @@ memcmp16_s (const uint16_t *dest, rsize_t dmax,
 
     if (smax > dmax) {
        invoke_safe_mem_constraint_handler("memcmp16_s: smax exceeds dmax",
-                  NULL, ESLEMAX);
-       return (RCNEGATE(ESLEMAX));
+                  NULL, ESNOSPC);
+       return (RCNEGATE(ESNOSPC));
     }
 
     /*

--- a/src/safeclib/memcmp32_s.c
+++ b/src/safeclib/memcmp32_s.c
@@ -133,8 +133,8 @@ memcmp32_s (const uint32_t *dest, rsize_t dmax,
 
     if (smax > dmax) {
        invoke_safe_mem_constraint_handler("memcmp32_s: smax exceeds dmax",
-                  NULL, ESLEMAX);
-       return (RCNEGATE(ESLEMAX));
+                  NULL, ESNOSPC);
+       return (RCNEGATE(ESNOSPC));
     }
 
     /*

--- a/src/safeclib/memcmp_s.c
+++ b/src/safeclib/memcmp_s.c
@@ -139,8 +139,8 @@ memcmp_s (const void *dest, rsize_t dmax,
 
     if (smax > dmax) {
         invoke_safe_mem_constraint_handler("memcmp_s: smax exceeds dmax",
-                   NULL, ESLEMAX);
-        return (RCNEGATE(ESLEMAX));
+                   NULL, ESNOSPC);
+        return (RCNEGATE(ESNOSPC));
     }
 
     /*

--- a/src/safeclib/memcpy16_s.c
+++ b/src/safeclib/memcpy16_s.c
@@ -119,8 +119,8 @@ memcpy16_s (uint16_t *dest, rsize_t dmax, const uint16_t *src, rsize_t smax)
     if (smax > dmax) {
         mem_prim_set16(dest, dmax, 0);
         invoke_safe_mem_constraint_handler("memcpy16_s: smax exceeds dmax",
-                   NULL, ESLEMAX);
-        return (RCNEGATE(ESLEMAX));
+                   NULL, ESNOSPC);
+        return (RCNEGATE(ESNOSPC));
     }
 
     if (src == NULL) {

--- a/src/safeclib/memcpy32_s.c
+++ b/src/safeclib/memcpy32_s.c
@@ -118,8 +118,8 @@ memcpy32_s (uint32_t *dest, rsize_t dmax, const uint32_t *src, rsize_t smax)
     if (smax > dmax) {
         mem_prim_set32(dest, dmax, 0);
         invoke_safe_mem_constraint_handler("memcpy32_s: smax exceeds dmax",
-                   NULL, ESLEMAX);
-        return (RCNEGATE(ESLEMAX));
+                   NULL, ESNOSPC);
+        return (RCNEGATE(ESNOSPC));
     }
 
     if (src == NULL) {

--- a/src/safeclib/memcpy_s.c
+++ b/src/safeclib/memcpy_s.c
@@ -124,8 +124,8 @@ memcpy_s(void * restrict dest, rsize_t dmax, const void * restrict src, rsize_t 
     if (smax > dmax) {
         mem_prim_set(dp, dmax, 0);
         invoke_safe_mem_constraint_handler("memcpy_s: smax exceeds dmax",
-                   NULL, ESLEMAX);
-        return RCNEGATE(ESLEMAX);
+                   NULL, ESNOSPC);
+        return RCNEGATE(ESNOSPC);
     }
 
     if (sp == NULL) {

--- a/src/safeclib/memcpy_s.c
+++ b/src/safeclib/memcpy_s.c
@@ -42,7 +42,7 @@
  * SYNOPSIS
  *    #include "safe_mem_lib.h"
  *    errno_t
- *    memcpy_s(void *dest, rsize_t dmax, const void *src, rsize_t smax)
+ *    memcpy_s(void * restrict dest, rsize_t dmax, const void * restrict src, rsize_t smax)
  *
  * DESCRIPTION
  *    This function copies at most smax bytes from src to dest, up to
@@ -88,7 +88,7 @@
  *
  */
 errno_t
-memcpy_s (void *dest, rsize_t dmax, const void *src, rsize_t smax)
+memcpy_s(void * restrict dest, rsize_t dmax, const void * restrict src, rsize_t smax)
 {
     uint8_t *dp;
     const uint8_t  *sp;

--- a/src/safeclib/memmove16_s.c
+++ b/src/safeclib/memmove16_s.c
@@ -129,8 +129,8 @@ memmove16_s (uint16_t *dest, rsize_t dmax, const uint16_t *src, rsize_t smax)
     if (smax > dmax) {
         mem_prim_set16(dp, dmax, 0);
         invoke_safe_mem_constraint_handler("memove16_s: smax exceeds dmax",
-                   NULL, ESLEMAX);
-        return (RCNEGATE(ESLEMAX));
+                   NULL, ESNOSPC);
+        return (RCNEGATE(ESNOSPC));
     }
 
     if (sp == NULL) {

--- a/src/safeclib/memmove32_s.c
+++ b/src/safeclib/memmove32_s.c
@@ -129,8 +129,8 @@ memmove32_s (uint32_t *dest, rsize_t dmax, const uint32_t *src, rsize_t smax)
     if (smax > dmax) {
         mem_prim_set32(dp, dmax, 0);
         invoke_safe_mem_constraint_handler("memove32_s: smax exceeds dmax",
-                   NULL, ESLEMAX);
-        return (RCNEGATE(ESLEMAX));
+                   NULL, ESNOSPC);
+        return (RCNEGATE(ESNOSPC));
     }
 
     if (sp == NULL) {

--- a/src/safeclib/memmove_s.c
+++ b/src/safeclib/memmove_s.c
@@ -128,8 +128,8 @@ memmove_s (void *dest, rsize_t dmax, const void *src, rsize_t smax)
     if (smax > dmax) {
         mem_prim_set(dp, dmax, 0);
         invoke_safe_mem_constraint_handler("memmove_s: smax exceeds max",
-                   NULL, ESLEMAX);
-        return (RCNEGATE(ESLEMAX));
+                   NULL, ESNOSPC);
+        return (RCNEGATE(ESNOSPC));
     }
 
     if (sp == NULL) {

--- a/src/safeclib/memset16_s.c
+++ b/src/safeclib/memset16_s.c
@@ -119,8 +119,8 @@ memset16_s(uint16_t *dest, rsize_t smax, uint16_t value, rsize_t n)
 
     if (n > smax/2) {
         invoke_safe_mem_constraint_handler("memset16_s: n exceeds smax/2",
-                   NULL, ESLEMAX);
-        err = ESLEMAX;
+                   NULL, ESNOSPC);
+        err = ESNOSPC;
         n = smax/2;
     }
 

--- a/src/safeclib/memset32_s.c
+++ b/src/safeclib/memset32_s.c
@@ -118,8 +118,8 @@ memset32_s(uint32_t *dest, rsize_t smax, uint32_t value, rsize_t n)
 
     if (n > smax/4) {
         invoke_safe_mem_constraint_handler("memset32_s: n exceeds smax/4",
-                   NULL, ESLEMAX);
-        err = ESLEMAX;
+                   NULL, ESNOSPC);
+        err = ESNOSPC;
         n = smax/4;
     }
 

--- a/src/safeclib/memset_s.c
+++ b/src/safeclib/memset_s.c
@@ -119,8 +119,8 @@ memset_s (void *dest, rsize_t smax, uint8_t value, rsize_t n)
 
     if (n > smax) {
         invoke_safe_mem_constraint_handler("memset_s: n exceeds smax",
-                   NULL, ESLEMAX);
-        err = ESLEMAX;
+                   NULL, ESNOSPC);
+        err = ESNOSPC;
         n = smax;
     }
 

--- a/src/safeclib/sprintf_s.c
+++ b/src/safeclib/sprintf_s.c
@@ -10,7 +10,7 @@
  * SYNOPSIS
  *    #include "safe_str_lib.h"
  *    errno_t 
- *    sprintf_s(char *dest, rsize_t dmax, const char *fmt, ...)
+ *    sprintf_s(char * restrict dest, rsize_t dmax, const char * restrict fmt, ...)
  *
  * DESCRIPTION
  *    The sprintf_s function composes a string with same test that 
@@ -42,7 +42,7 @@
  *     ESLEMAX    length exceeds max limit
  */
 
-int sprintf_s(char *dest, rsize_t dmax, const char *fmt, ...)
+int sprintf_s(char * restrict dest, rsize_t dmax, const char * restrict fmt, ...)
 {
     va_list ap;
     int ret = -1;

--- a/src/safeclib/sprintf_s.c
+++ b/src/safeclib/sprintf_s.c
@@ -76,9 +76,9 @@ int sprintf_s(char * restrict dest, rsize_t dmax, const char * restrict fmt, ...
 
     if (ret >= (int)dmax) {
         invoke_safe_str_constraint_handler("sprintf_s: len exceeds dmax",
-                   NULL, ESLEMAX);
+                   NULL, ESNOSPC);
         *dest = 0;
-        ret = RCNEGATE(ESLEMAX);
+        ret = RCNEGATE(ESNOSPC);
     }
 
     va_end(ap);

--- a/src/safeclib/strcat_s.c
+++ b/src/safeclib/strcat_s.c
@@ -41,7 +41,7 @@
  * SYNOPSIS
  *    #include "safe_str_lib.h"
  *    errno_t
- *    strcat_s(char *dest, rsize_t dmax, const char *src)
+ *    strcat_s(char * restrict dest, rsize_t dmax, const char * restrict src)
  *
  * DESCRIPTION
  *    The strcat_s function appends a copy of the string pointed
@@ -98,7 +98,7 @@
  *
  */
 errno_t
-strcat_s (char *dest, rsize_t dmax, const char *src)
+strcat_s (char * restrict dest, rsize_t dmax, const char * restrict src)
 {
     rsize_t orig_dmax;
     char *orig_dest;

--- a/src/safeclib/strcpy_s.c
+++ b/src/safeclib/strcpy_s.c
@@ -41,7 +41,7 @@
  * SYNOPSIS
  *    #include "safe_str_lib.h"
  *    errno_t
- *    strcpy_s(char *dest, rsize_t dmax, const char *src)
+ *    strcpy_s(char * restrict dest, rsize_t dmax, const char * restrict src)
  *
  * DESCRIPTION
  *    The strcpy_s function copies the string pointed to by src
@@ -91,7 +91,7 @@
  *
  */
 errno_t
-strcpy_s (char *dest, rsize_t dmax, const char *src)
+strcpy_s (char * restrict dest, rsize_t dmax, const char * restrict src)
 {
     rsize_t orig_dmax;
     char *orig_dest;

--- a/src/safeclib/strcpyfld_s.c
+++ b/src/safeclib/strcpyfld_s.c
@@ -137,8 +137,8 @@ strcpyfld_s (char *dest, rsize_t dmax, const char *src, rsize_t slen)
         while (dmax) {  *dest = '\0'; dmax--; dest++; }
 
         invoke_safe_str_constraint_handler("strcpyfld_s: src exceeds max",
-                   NULL, ESLEMAX);
-        return (ESLEMAX);
+                   NULL, ESNOSPC);
+        return (ESNOSPC);
     }
 
 

--- a/src/safeclib/strcpyfldin_s.c
+++ b/src/safeclib/strcpyfldin_s.c
@@ -139,8 +139,8 @@ strcpyfldin_s (char *dest, rsize_t dmax, const char *src, rsize_t slen)
         while (dmax) {  *dest = '\0'; dmax--; dest++; }
 
         invoke_safe_str_constraint_handler("strcpyfldin_s: slen exceeds max",
-                   NULL, ESLEMAX);
-        return (ESLEMAX);
+                   NULL, ESNOSPC);
+        return (ESNOSPC);
     }
 
 

--- a/src/safeclib/strcpyfldout_s.c
+++ b/src/safeclib/strcpyfldout_s.c
@@ -141,8 +141,8 @@ strcpyfldout_s (char *dest, rsize_t dmax, const char *src, rsize_t slen)
         while (dmax) {  *dest = '\0'; dmax--; dest++; }
 
         invoke_safe_str_constraint_handler("strcpyfldout_s: slen exceeds max",
-                   NULL, ESLEMAX);
-        return (ESLEMAX);
+                   NULL, ESNOSPC);
+        return (ESNOSPC);
     }
 
 

--- a/src/safeclib/strncat_s.c
+++ b/src/safeclib/strncat_s.c
@@ -41,7 +41,7 @@
  * SYNOPSIS
  *    #include "safe_str_lib.h"
  *    errno_t
- *    strncat_s(char *dest, rsize_t dmax, const char *src, rsize_t slen)
+ *    strncat_s(char * restrict dest, rsize_t dmax, const char * restrict src, rsize_t slen)
  *
  * DESCRIPTION
  *    The strncat_s function appends a copy of the string pointed
@@ -98,7 +98,7 @@
  *
  */
 errno_t
-strncat_s (char *dest, rsize_t dmax, const char *src, rsize_t slen)
+strncat_s (char * restrict dest, rsize_t dmax, const char * restrict src, rsize_t slen)
 {
     rsize_t orig_dmax;
     char *orig_dest;

--- a/src/safeclib/strncpy_s.c
+++ b/src/safeclib/strncpy_s.c
@@ -41,7 +41,7 @@
  * SYNOPSIS
  *    #include "safe_str_lib.h"
  *    errno_t
- *    strncpy_s(char *dest, rsize_t dmax, const char *src, rsize_t slen)
+ *    strncpy_s(char * restrict dest, rsize_t dmax, const char * restrict src, rsize_t slen)
  *
  * DESCRIPTION
  *    The strncpy_s function copies not more than slen successive characters
@@ -98,7 +98,7 @@
  *-
  */
 errno_t
-strncpy_s (char *dest, rsize_t dmax, const char *src, rsize_t slen)
+strncpy_s(char * restrict dest, rsize_t dmax, const char * restrict src, rsize_t slen)
 {
     rsize_t orig_dmax;
     char *orig_dest;

--- a/src/safeclib/strtok_s.c
+++ b/src/safeclib/strtok_s.c
@@ -41,7 +41,7 @@
  * SYNOPSIS
  *    #include "safe_str_lib.h"
  *    char *
- *    strtok_s(char *dest, rsize_t *dmax, char *src, char **ptr)
+ *    strtok_s(char * restrict dest, rsize_t * restrict dmax, const char * restrict src, char ** restrict ptr)
  *
  * DESCRIPTION
  *    A sequence of calls to the strtok_s function breaks the string
@@ -169,7 +169,7 @@
  *-
  */
 char *
-strtok_s(char *dest, rsize_t *dmax, const char *src, char **ptr)
+strtok_s(char * restrict dest, rsize_t * restrict dmax, const char * restrict src, char ** restrict ptr)
 {
 
 /*

--- a/src/safeclib/strtolowercase_s.c
+++ b/src/safeclib/strtolowercase_s.c
@@ -41,7 +41,7 @@
  * SYNOPSIS
  *    #include "safe_str_lib.h"
  *    errno_t
- *    strlolowercase_s(char *dest, rsize_t dmax)
+ *    strlolowercase_s(char * restrict dest, rsize_t dmax)
  *
  * DESCRIPTION
  *    Scans the string converting uppercase characters to
@@ -78,7 +78,7 @@
  *
  */
 errno_t
-strtolowercase_s (char *dest, rsize_t dmax)
+strtolowercase_s(char * restrict dest, rsize_t dmax)
 {
     if (!dest) {
         invoke_safe_str_constraint_handler("strtolowercase_s: "


### PR DESCRIPTION
## Description

### Change 1: Add `restrict` keyword to all implemented interfaces per the C11 Annex K standard.
"The restrict keyword is a declaration of intent given by the programmer to the compiler. It says that for the lifetime of the pointer, only the pointer itself or a value directly derived from it (such as pointer + 1) will be used to access the object to which it points. This limits the effects of pointer aliasing, aiding optimizations." per [wikipedia](https://en.wikipedia.org/wiki/Restrict).

Note that compilers often implement a compiler-specific keyword version of `restrict` and may or may not actually define the standard 'restrict' keyword itself. For instance:
GCC: `__restrict__` and `__restrict`
MSVC: `__restrict`
IAR: `_Restrict`
Renesas RX Hew: `_Restrict` and `restrict`

We solved this in our code by using a "restrict.h" header which would conditionally define the restrict keyword for known compilers. Another method in cmake is to test compiling code with different versions of the `restrict` keyword to determine which one is available and then mapping the 'restrict' keyword to whatever is available. However, this repository in `configure.ac` uses `AC_C_RESTRICT` keyword which gnu [defines](https://www.gnu.org/software/autoconf/manual/autoconf-2.60/html_node/C-Compiler.html) as:

> If the C compiler recognizes the restrict keyword, don't do anything. If it recognizes only a variant spelling (__restrict, __restrict__, or _Restrict), then define restrict to that. Otherwise, define restrict to be empty. Thus, programs may simply use restrict as if every C compiler supported it; for those that do not, the makefile or configuration header defines it away.

So there should be no harm in inserting the `restrict` keyword for all applicable pointers per the standard since it would either be removed or matched to each compiler's keyword.

### Change 2: Return ESNOSPC for `(smax > dmax)` overflow checks.
The following two error codes are defined in safe_lib_errno.h:
ESLEMAX - "length exceeds max"
ESNOSPC - "not enough space for s2"

However, we saw in the code that ESLEMAX error code was being returned for cases where both `if (dmax > RSIZE_MAX_MEM)` and `if (smax > dmax)`. The first is an invalid input condition always and the second is an invalid input condition dependent on whether there is enough space in the destination buffer for the source data. Therefore we think that the second error condition should use error code ESNOSPC instead of ESLEMAX.

The reason we discovered this discrepancy is that we are trying to provide a common C11AnnexK wrapper interface in our code, allowing use of compiler-specific implementations by Microsoft, IAR, and Renesas, while using this library for GCC. However, we need to normalize the error codes returned and the other libraries use only error codes EINVAL(22) and ERANGE(34) instead of the more targeted error codes used by safeclib.

GNU defines EINVAL as "“Invalid argument.” This is used to indicate various kinds of problems with passing the wrong argument to a library function."
GNU defines ERANGE as "“Numerical result out of range.” Used by mathematical functions when the result value is not representable because of overflow or underflow."

In our usage of safeclib we overwrite each error code in safe_lib_errno.h to map to either EINVAL or ERANGE. However, ESLEMAX causes problems because it is used for both situations in the code. Therefore we are proposing that ESNOSPC 'no space' is more appropriate for the ERANGE situtations where there's a possible overflow condition, and suggest a definition clarification in safe_lib_errno.h that ESLEMAX is "length exceeds RSIZE_MAX". I know that safelib uses string- and memory-specific RSIZE_MAX variables so we could be more exact and list those, but I thought this description was acceptable and succinct.

## Reviewers
@rurban 

## Observers
@Juno-Explorer - Arjun Gour - coworker/coauthor