### PR TITLE
Added doxygen tags to SafeC header comments.

### DIFF
--- a/src/safeclib/abort_handler_s.c
+++ b/src/safeclib/abort_handler_s.c
@@ -32,36 +32,23 @@
 #include "safeclib_private.h"
 
 /**
- * NAME
- *    abort_handler_s
- *
- * SYNOPSIS
- *    #include "safe_lib.h"
- *    void abort_handler_s(const char * restrict msg, void * restrict ptr, errno_t error)
- *
- * DESCRIPTION
+ * @brief
  *    This function writes a message on the standard error stream in
  *    an implementation-defined format. The message shall include the
  *    string pointed to by msg. The abort_handler_s function then calls
  *    the abort function.
  *
- * SPECIFIED IN
+ * @remark SPECIFIED IN
  *    ISO/IEC JTC1 SC22 WG14 N1172, Programming languages, environments
  *    and system software interfaces, Extensions to the C Library,
  *    Part I: Bounds-checking interfaces
  *
- * INPUT PARAMETERS
- *    msg       Pointer to the message describing the error
+ * @param[in] msg    Pointer to the message describing the error
+ * @param[in] ptr    Pointer to aassociated data.  Can be NULL.
+ * @param[in] error  The error code encountered.
  *
- *    ptr       Pointer to aassociated data.  Can be NULL.
- *
- *    error     The error code encountered.
- *
- * RETURN VALUE
- *    Does not return to caller.
- *
- * ALSO SEE
- *    ignore_handler_s()
+ * @see 
+ * ignore_handler_s()
  *
  */
 

--- a/src/safeclib/ignore_handler_s.c
+++ b/src/safeclib/ignore_handler_s.c
@@ -32,32 +32,19 @@
 #include "safeclib_private.h"
 
 /**
- * NAME
- *    ignore_handler_s
- *
- * SYNOPSIS
- *    #include "safe_lib.h"
- *    void ignore_handler_s(const char * restrict msg, void * restrict ptr, errno_t error)
- *
- * DESCRIPTION
+ * @brief
  *    This function simply returns to the caller.
  *
- * SPECIFIED IN
+ * @remark SPECIFIED IN
  *    ISO/IEC JTC1 SC22 WG14 N1172, Programming languages, environments
  *    and system software interfaces, Extensions to the C Library,
  *    Part I: Bounds-checking interfaces
  *
- * INPUT PARAMETERS
- *    msg       Pointer to the message describing the error
+ * @param[in] msg    Pointer to the message describing the error
+ * @param[in] ptr    Pointer to aassociated data.  Can be NULL.
+ * @param[in] error  The error code encountered.
  *
- *    ptr       Pointer to aassociated data.  Can be NULL.
- *
- *    error     The error code encountered.
- *
- * RETURN VALUE
- *    Returns no value.
- *
- * ALSO SEE
+ * @see 
  *    abort_handler_s()
  *
  */

--- a/src/safeclib/mem_primitives_lib.c
+++ b/src/safeclib/mem_primitives_lib.c
@@ -39,33 +39,16 @@
  */
 
 /**
- * NAME
- *    mem_prim_set - Sets memory to value
+ * @brief
+ *    Sets dmax bytes starting at dest to the specified value
  *
- * SYNOPSIS
- *    #include "mem_primitives_lib.h"
- *    void
- *    mem_prim_set(void *dest, uint32_t len, uint8_t value)
- *
- * DESCRIPTION
- *    Sets len bytes starting at dest to the specified value
- *
- * INPUT PARAMETERS
- *    dest - pointer to memory that will be set to value
- *
- *    len - number of bytes to be set
- *
- *    value - byte value
- *
- * OUTPUT PARAMETERS
- *    dest - is updated
- *
- * RETURN VALUE
- *    none
+ * @param[out] dest   pointer to memory that will be set to value
+ * @param[in]  dmax   number of bytes to be set
+ * @param[in]  value  byte value
  *
  */
 void
-mem_prim_set (void *dest, uint32_t len, uint8_t value)
+mem_prim_set (void *dest, uint32_t dmax, uint8_t value)
 {
     uint8_t *dp;
     uint32_t count;
@@ -74,7 +57,7 @@ mem_prim_set (void *dest, uint32_t len, uint8_t value)
     uint32_t *lp;
     uint32_t value32;
 
-    count = len;
+    count = dmax;
 
     dp = (uint8_t*) dest;
 
@@ -149,39 +132,23 @@ mem_prim_set (void *dest, uint32_t len, uint8_t value)
 
 
 /**
- * NAME
- *    mem_prim_set16 - Sets memory to value
- *
- * SYNOPSIS
- *    #include "mem_primitives_lib.h"
- *    void
- *    mem_prim_set16(uint16_t *dp, uint32_t len, uint16_t value)
- *
- * DESCRIPTION
- *    Sets len uint16_ts starting at dest to the specified value.
+ * @brief
+ *    Sets dmax uint16_ts starting at dest to the specified value.
  *    Pointers must meet system alignment requirements.
  *
- * INPUT PARAMETERS
- *    dest - pointer to memory that will be set to value
- *
- *    len - number of uint16_ts to be set
- *
- *    value - uint16_t value
- *
- * OUTPUT PARAMETERS
- *    dest - is updated
- *
- * RETURN VALUE
- *    none
+ * @param[out] dest  pointer to memory that will be set to value
+ * @param[in]  dmax  number of uint16_ts to be set
+ * @param[in]  value uint16_t value
  *
  */
 void
-mem_prim_set16 (uint16_t *dp, uint32_t len, uint16_t value)
+mem_prim_set16 (uint16_t *dest, uint32_t dmax, uint16_t value)
 {
 
-    while (len != 0) {
+    uint16_t *dp = dest;
+    while (dmax != 0) {
 
-        switch (len) {
+        switch (dmax) {
         /*
          * Here we do blocks of 8.  Once the remaining count
          * drops below 8, take the fast track to finish up.
@@ -191,7 +158,7 @@ mem_prim_set16 (uint16_t *dp, uint32_t len, uint16_t value)
             *dp++ = value; *dp++ = value; *dp++ = value; *dp++ = value;
             *dp++ = value; *dp++ = value; *dp++ = value; *dp++ = value;
             *dp++ = value; *dp++ = value; *dp++ = value; *dp++ = value;
-            len -= 16;
+            dmax -= 16;
             break;
 
         case 15:  *dp++ = value;
@@ -210,7 +177,7 @@ mem_prim_set16 (uint16_t *dp, uint32_t len, uint16_t value)
         case 3:  *dp++ = value;
         case 2:  *dp++ = value;
         case 1:  *dp++ = value;
-            len = 0;
+            dmax = 0;
             break;
         }
     } /* end while */
@@ -220,39 +187,23 @@ mem_prim_set16 (uint16_t *dp, uint32_t len, uint16_t value)
 
 
 /**
- * NAME
- *    mem_prim_set32 - Sets memory to the uint32_t value
- *
- * SYNOPSIS
- *    #include "mem_primitives_lib.h"
- *    void
- *    mem_prim_set32(uint32_t *dp, uint32_t len, uint32_t value)
- *
- * DESCRIPTION
- *    Sets len uint32_ts starting at dest to the specified value
+ * @brief
+ *    Sets dmax uint32_ts starting at dest to the specified value
  *    Pointers must meet system alignment requirements.
  *
- * INPUT PARAMETERS
- *    dest - pointer to memory that will be set to value
+ * @param[out] dest   pointer to memory that will be set to value
+ * @param[in]  dmax   number of uint32_ts to be set
+ * @param[in]  value  uint32_t value
  *
- *    len - number of uint32_ts to be set
- *
- *    value - uint32_t value
- *
- * OUTPUT PARAMETERS
- *    dest - is updated
- *
- * RETURN VALUE
- *    none
  *
  */
 void
-mem_prim_set32 (uint32_t *dp, uint32_t len, uint32_t value)
+mem_prim_set32 (uint32_t *dest, uint32_t dmax, uint32_t value)
 {
+    uint32_t *dp = dest;
+    while (dmax != 0) {
 
-    while (len != 0) {
-
-        switch (len) {
+        switch (dmax) {
         /*
          * Here we do blocks of 8.  Once the remaining count
          * drops below 8, take the fast track to finish up.
@@ -262,7 +213,7 @@ mem_prim_set32 (uint32_t *dp, uint32_t len, uint32_t value)
             *dp++ = value; *dp++ = value; *dp++ = value; *dp++ = value;
             *dp++ = value; *dp++ = value; *dp++ = value; *dp++ = value;
             *dp++ = value; *dp++ = value; *dp++ = value; *dp++ = value;
-            len -= 16;
+            dmax -= 16;
             break;
 
         case 15:  *dp++ = value;
@@ -281,7 +232,7 @@ mem_prim_set32 (uint32_t *dp, uint32_t len, uint32_t value)
         case 3:  *dp++ = value;
         case 2:  *dp++ = value;
         case 1:  *dp++ = value;
-            len = 0;
+            dmax = 0;
             break;
         }
     } /* end while */
@@ -291,35 +242,17 @@ mem_prim_set32 (uint32_t *dp, uint32_t len, uint32_t value)
 
 
 /**
- * NAME
- *    mem_prim_move - Move (handles overlap) memory
+ * @brief
+ *    Moves at most length of bytes from src to dest, up to dmax bytes. 
+ *    Dest may overlap with src.
  *
- * SYNOPSIS
- *    #include "mem_primitives_lib.h"
- *    void
- *    mem_prim_move(void *dest, const void *src, uint32_t len)
- *
- * DESCRIPTION
- *    Moves at most slen bytes from src to dest, up to dmax
- *    bytes.   Dest may overlap with src.
- *
- * INPUT PARAMETERS
- *    dest - pointer to the memory that will be replaced by src.
- *
- *    src - pointer to the memory that will be copied
- *          to dest
- *
- *    len - maximum number bytes of src that can be copied
- *
- * OUTPUT PARAMETERS
- *    dest - is updated
- *
- * RETURN VALUE
- *    none
+ * @param[out] dest     pointer to the memory that will be replaced by src.
+ * @param[in]  src      pointer to the memory that will be copied to dest
+ * @param[in]  length   maximum number bytes of src that can be copied
  *
  */
 void
-mem_prim_move (void *dest, const void *src, uint32_t len)
+mem_prim_move (void *dest, const void *src, uint32_t length)
 {
 
 #define wsize   sizeof(uint32_t)
@@ -351,14 +284,14 @@ mem_prim_move (void *dest, const void *src, uint32_t len)
             /*
              * determine how many bytes to copy to align operands
              */
-            if ((tsp ^ (uintptr_t)dp) & wmask || len < wsize) {
-                tsp = len;
+            if ((tsp ^ (uintptr_t)dp) & wmask || length < wsize) {
+                tsp = length;
 
             } else {
                 tsp = wsize - (tsp & wmask);
             }
 
-            len -= tsp;
+            length -= tsp;
 
             /*
              * make the alignment
@@ -371,7 +304,7 @@ mem_prim_move (void *dest, const void *src, uint32_t len)
         /*
          * Now copy, then mop up any trailing bytes.
          */
-        tsp = len / wsize;
+        tsp = length / wsize;
 
         if (tsp > 0) {
 
@@ -386,7 +319,7 @@ mem_prim_move (void *dest, const void *src, uint32_t len)
         /*
          * copy over the remaining bytes and we're done
          */
-        tsp = len & wmask;
+        tsp = length & wmask;
 
         if (tsp > 0) {
             do {
@@ -404,8 +337,8 @@ mem_prim_move (void *dest, const void *src, uint32_t len)
         /*
          * go to end of the memory to copy
          */
-        sp += len;
-        dp += len;
+        sp += length;
+        dp += length;
 
         /*
          * get a working copy of src for bit operations
@@ -417,13 +350,13 @@ mem_prim_move (void *dest, const void *src, uint32_t len)
          */
         if ((tsp | (uintptr_t)dp) & wmask) {
 
-            if ((tsp ^ (uintptr_t)dp) & wmask || len <= wsize) {
-                tsp = len;
+            if ((tsp ^ (uintptr_t)dp) & wmask || length <= wsize) {
+                tsp = length;
             } else {
                 tsp &= wmask;
             }
 
-            len -= tsp;
+            length -= tsp;
 
             /*
              * make the alignment
@@ -436,7 +369,7 @@ mem_prim_move (void *dest, const void *src, uint32_t len)
         /*
          * Now copy in uint32_t units, then mop up any trailing bytes.
          */
-        tsp = len / wsize;
+        tsp = length / wsize;
 
         if (tsp > 0) {
             do {
@@ -450,9 +383,9 @@ mem_prim_move (void *dest, const void *src, uint32_t len)
         /*
          * copy over the remaining bytes and we're done
          */
-        tsp = len & wmask;
+        tsp = length & wmask;
         if (tsp > 0) {
-            tsp = len & wmask;
+            tsp = length & wmask;
             do {
                 *--dp = *--sp;
             } while (--tsp);
@@ -464,37 +397,21 @@ mem_prim_move (void *dest, const void *src, uint32_t len)
 
 
 /**
- * NAME
- *    mem_prim_move8 - Move (handles overlap) memory
- *
- * SYNOPSIS
- *    #include "mem_primitives_lib.h"
- *    void
- *    mem_prim_move8(void *dest, const void *src, uint32_t len)
- *
- * DESCRIPTION
- *    Moves at most len uint8_ts from sp to dp.
+ * @brief
+ *    Moves at most length of uint8_ts from src to dest.
  *    The destination may overlap with source.
  *
- * INPUT PARAMETERS
- *    dp - pointer to the memory that will be replaced by sp.
+ * @param[out] dest    pointer to the memory that will be replaced by src
+ * @param[in]  src     pointer to the memory that will be copied to dest
+ * @param[in]  length  maximum number uint8_t of src that can be copied
  *
- *    sp - pointer to the memory that will be copied
- *         to dp
- *
- *    len - maximum number uint8_t of sp that can be copied
- *
- * OUTPUT PARAMETERS
- *    dp - pointer to the memory that will be replaced by sp.
- *
- * RETURN VALUE
- *    none
  *
  */
 void
-mem_prim_move8 (uint8_t *dp, const uint8_t *sp, uint32_t len)
+mem_prim_move8 (uint8_t *dest, const uint8_t *src, uint32_t length)
 {
-
+    uint8_t *dp = dest;
+	const uint8_t *sp = src;
     /*
      * Determine if we need to copy forward or backward (overlap)
      */
@@ -503,9 +420,9 @@ mem_prim_move8 (uint8_t *dp, const uint8_t *sp, uint32_t len)
          * Copy forward.
          */
 
-         while (len != 0) {
+         while (length != 0) {
 
-             switch (len) {
+             switch (length) {
              /*
               * Here we do blocks of 8.  Once the remaining count
               * drops below 8, take the fast track to finish up.
@@ -515,7 +432,7 @@ mem_prim_move8 (uint8_t *dp, const uint8_t *sp, uint32_t len)
                   *dp++ = *sp++; *dp++ = *sp++; *dp++ = *sp++; *dp++ = *sp++;
                   *dp++ = *sp++; *dp++ = *sp++; *dp++ = *sp++; *dp++ = *sp++;
                   *dp++ = *sp++; *dp++ = *sp++; *dp++ = *sp++; *dp++ = *sp++;
-                  len -= 16;
+                  length -= 16;
                   break;
 
              case 15:  *dp++ = *sp++;
@@ -534,7 +451,7 @@ mem_prim_move8 (uint8_t *dp, const uint8_t *sp, uint32_t len)
              case 3:  *dp++ = *sp++;
              case 2:  *dp++ = *sp++;
              case 1:  *dp++ = *sp++;
-                 len = 0;
+                 length = 0;
                  break;
              }
          } /* end while */
@@ -550,12 +467,12 @@ mem_prim_move8 (uint8_t *dp, const uint8_t *sp, uint32_t len)
         /*
          * go to end of the memory to copy
          */
-        sp += len;
-        dp += len;
+        sp += length;
+        dp += length;
 
-        while (len != 0) {
+        while (length != 0) {
 
-            switch (len) {
+            switch (length) {
             /*
              * Here we do blocks of 8.  Once the remaining count
              * drops below 8, take the fast track to finish up.
@@ -565,7 +482,7 @@ mem_prim_move8 (uint8_t *dp, const uint8_t *sp, uint32_t len)
                  *--dp = *--sp; *--dp = *--sp; *--dp = *--sp; *--dp = *--sp;
                  *--dp = *--sp; *--dp = *--sp; *--dp = *--sp; *--dp = *--sp;
                  *--dp = *--sp; *--dp = *--sp; *--dp = *--sp; *--dp = *--sp;
-                 len -= 16;
+                 length -= 16;
                  break;
 
             case 15:  *--dp = *--sp;
@@ -584,7 +501,7 @@ mem_prim_move8 (uint8_t *dp, const uint8_t *sp, uint32_t len)
             case 3:  *--dp = *--sp;
             case 2:  *--dp = *--sp;
             case 1:  *--dp = *--sp;
-                len = 0;
+                length = 0;
                 break;
             }
         } /* end while */
@@ -595,37 +512,20 @@ mem_prim_move8 (uint8_t *dp, const uint8_t *sp, uint32_t len)
 
 
 /**
- * NAME
- *    mem_prim_move16 - Move (handles overlap) memory
- *
- * SYNOPSIS
- *    #include "mem_primitives_lib.h"
- *    void
- *    mem_prim_move16(void *dest, const void *src, uint32_t len)
- *
- * DESCRIPTION
- *    Moves at most len uint16_ts from sp to dp.
+ * @brief
+ *    Moves at most length uint16_ts from src to dest.
  *    The destination may overlap with source.
  *
- * INPUT PARAMETERS
- *    dp - pointer to the memory that will be replaced by sp.
- *
- *    sp - pointer to the memory that will be copied
- *         to dp
- *
- *    len - maximum number uint16_t of sp that can be copied
- *
- * OUTPUT PARAMETERS
- *    dp - is updated
- *
- * RETURN VALUE
- *    none
+ * @param[out] dest    pointer to the memory that will be replaced by src.
+ * @param[in]  src     pointer to the memory that will be copied to dest
+ * @param[in]  length  maximum number uint16_t of src that can be copied
  *
  */
 void
-mem_prim_move16 (uint16_t *dp, const uint16_t *sp, uint32_t len)
+mem_prim_move16 (uint16_t *dest, const uint16_t *src, uint32_t length)
 {
-
+    uint16_t *dp = dest;
+    const uint16_t *sp = src;
     /*
      * Determine if we need to copy forward or backward (overlap)
      */
@@ -634,9 +534,9 @@ mem_prim_move16 (uint16_t *dp, const uint16_t *sp, uint32_t len)
          * Copy forward.
          */
 
-         while (len != 0) {
+         while (length != 0) {
 
-             switch (len) {
+             switch (length) {
              /*
               * Here we do blocks of 8.  Once the remaining count
               * drops below 8, take the fast track to finish up.
@@ -646,7 +546,7 @@ mem_prim_move16 (uint16_t *dp, const uint16_t *sp, uint32_t len)
                   *dp++ = *sp++; *dp++ = *sp++; *dp++ = *sp++; *dp++ = *sp++;
                   *dp++ = *sp++; *dp++ = *sp++; *dp++ = *sp++; *dp++ = *sp++;
                   *dp++ = *sp++; *dp++ = *sp++; *dp++ = *sp++; *dp++ = *sp++;
-                  len -= 16;
+                  length -= 16;
                   break;
 
              case 15:  *dp++ = *sp++;
@@ -665,7 +565,7 @@ mem_prim_move16 (uint16_t *dp, const uint16_t *sp, uint32_t len)
              case 3:  *dp++ = *sp++;
              case 2:  *dp++ = *sp++;
              case 1:  *dp++ = *sp++;
-                 len = 0;
+                 length = 0;
                  break;
              }
          } /* end while */
@@ -680,12 +580,12 @@ mem_prim_move16 (uint16_t *dp, const uint16_t *sp, uint32_t len)
         /*
          * go to end of the memory to copy
          */
-        sp += len;
-        dp += len;
+        sp += length;
+        dp += length;
 
-        while (len != 0) {
+        while (length != 0) {
 
-            switch (len) {
+            switch (length) {
             /*
              * Here we do blocks of 8.  Once the remaining count
              * drops below 8, take the fast track to finish up.
@@ -695,7 +595,7 @@ mem_prim_move16 (uint16_t *dp, const uint16_t *sp, uint32_t len)
                  *--dp = *--sp; *--dp = *--sp; *--dp = *--sp; *--dp = *--sp;
                  *--dp = *--sp; *--dp = *--sp; *--dp = *--sp; *--dp = *--sp;
                  *--dp = *--sp; *--dp = *--sp; *--dp = *--sp; *--dp = *--sp;
-                 len -= 16;
+                 length -= 16;
                  break;
 
             case 15:  *--dp = *--sp;
@@ -714,7 +614,7 @@ mem_prim_move16 (uint16_t *dp, const uint16_t *sp, uint32_t len)
             case 3:  *--dp = *--sp;
             case 2:  *--dp = *--sp;
             case 1:  *--dp = *--sp;
-                len = 0;
+                length = 0;
                 break;
             }
         } /* end while */
@@ -725,37 +625,20 @@ mem_prim_move16 (uint16_t *dp, const uint16_t *sp, uint32_t len)
 
 
 /**
- * NAME
- *    mem_prim_move32 - Move (handles overlap) memory
- *
- * SYNOPSIS
- *    #include "mem_primitives_lib.h"
- *    void
- *    mem_prim_move32(void *dest, const void *src, uint32_t len)
- *
- * DESCRIPTION
- *    Moves at most len uint32_ts from sp to dp.
+ * @brief 
+ *    Moves at most length of uint32_ts from src to dest.
  *    The destination may overlap with source.
  *
- * INPUT PARAMETERS
- *    dp - pointer to the memory that will be replaced by sp.
- *
- *    sp - pointer to the memory that will be copied
- *         to dp
- *
- *    len - maximum number uint32_t of sp that can be copied
- *
- * OUTPUT PARAMETERS
- *    dp - is updated
- *
- * RETURN VALUE
- *    none
+ * @param[out] dest    pointer to the memory that will be replaced by src.
+ * @param[in]  src     pointer to the memory that will be copied to dest
+ * @param[in]  length  maximum number uint32_t of sp that can be copied
  *
  */
 void
-mem_prim_move32 (uint32_t *dp, const uint32_t *sp, uint32_t len)
+mem_prim_move32 (uint32_t *dest, const uint32_t *src, uint32_t length)
 {
-
+    uint32_t *dp = dest;
+    const uint32_t *sp = src;
     /*
      * Determine if we need to copy forward or backward (overlap)
      */
@@ -764,9 +647,9 @@ mem_prim_move32 (uint32_t *dp, const uint32_t *sp, uint32_t len)
          * Copy forward.
          */
 
-         while (len != 0) {
+         while (length != 0) {
 
-             switch (len) {
+             switch (length) {
              /*
               * Here we do blocks of 8.  Once the remaining count
               * drops below 8, take the fast track to finish up.
@@ -776,7 +659,7 @@ mem_prim_move32 (uint32_t *dp, const uint32_t *sp, uint32_t len)
                   *dp++ = *sp++; *dp++ = *sp++; *dp++ = *sp++; *dp++ = *sp++;
                   *dp++ = *sp++; *dp++ = *sp++; *dp++ = *sp++; *dp++ = *sp++;
                   *dp++ = *sp++; *dp++ = *sp++; *dp++ = *sp++; *dp++ = *sp++;
-                  len -= 16;
+                  length -= 16;
                   break;
 
              case 15:  *dp++ = *sp++;
@@ -795,7 +678,7 @@ mem_prim_move32 (uint32_t *dp, const uint32_t *sp, uint32_t len)
              case 3:  *dp++ = *sp++;
              case 2:  *dp++ = *sp++;
              case 1:  *dp++ = *sp++;
-                 len = 0;
+                 length = 0;
                  break;
              }
          } /* end while */
@@ -809,12 +692,12 @@ mem_prim_move32 (uint32_t *dp, const uint32_t *sp, uint32_t len)
         /*
          * go to end of the memory to copy
          */
-        sp += len;
-        dp += len;
+        sp += length;
+        dp += length;
 
-        while (len != 0) {
+        while (length != 0) {
 
-            switch (len) {
+            switch (length) {
             /*
              * Here we do blocks of 8.  Once the remaining count
              * drops below 8, take the fast track to finish up.
@@ -824,7 +707,7 @@ mem_prim_move32 (uint32_t *dp, const uint32_t *sp, uint32_t len)
                  *--dp = *--sp; *--dp = *--sp; *--dp = *--sp; *--dp = *--sp;
                  *--dp = *--sp; *--dp = *--sp; *--dp = *--sp; *--dp = *--sp;
                  *--dp = *--sp; *--dp = *--sp; *--dp = *--sp; *--dp = *--sp;
-                 len -= 16;
+                 length -= 16;
                  break;
 
             case 15:  *--dp = *--sp;
@@ -843,7 +726,7 @@ mem_prim_move32 (uint32_t *dp, const uint32_t *sp, uint32_t len)
             case 3:  *--dp = *--sp;
             case 2:  *--dp = *--sp;
             case 1:  *--dp = *--sp;
-                len = 0;
+                length = 0;
                 break;
             }
         } /* end while */

--- a/src/safeclib/memcmp16_s.c
+++ b/src/safeclib/memcmp16_s.c
@@ -34,55 +34,37 @@
 #include "safe_mem_lib.h"
 
 /**
- * NAME
- *    memcmp16_s
- *
- * SYNOPSIS
- *    #include "safe_mem_lib.h"
- *    errno_t
- *    memcmp16_s(const uint16_t *dest, rsize_t dmax,
- *               const uint16_t *src,  rsize_t smax, int *diff)
- *
- * DESCRIPTION
+ * @brief
  *    Compares memory until they differ, and their difference is
  *    returned in diff.  If the block of memory is the same, diff=0.
  *
- * EXTENSION TO
+ * @remark EXTENSION TO
  *    ISO/IEC JTC1 SC22 WG14 N1172, Programming languages, environments
  *    and system software interfaces, Extensions to the C Library,
  *    Part I: Bounds-checking interfaces
  *
- *  INPUT PARAMETERS
- *    dest      pointer to memory to compare against
+ * @param  dest   pointer to memory to compare against
+ * @param  src    pointer to the source memory to compare with dest 
+ * @param  dmax   maximum length of dest, in bytess
+ * @param  smax   length of the source memory block
+ * @param  *diff  pointer to the diff which is an integer greater
+ *                than, equal to or less than zero according to
+ *                whether the object pointed to by dest is
+ *                greater than, equal to or less than the object
+ *                pointed to by src.
  *
- *    dmax      maximum length of dest, in uint16_t
+ * @pre   Neither dest nor src shall be a null pointer.
+ * @pre   Neither dmax nor smax shall be 0.
+ * @pre   dmax shall not be greater than RSIZE_MAX_MEM.
+ * @pre   smax shall not be greater than dmax.
  *
- *    src       pointer to the source memory to compare with dest
+ * @retval  EOK         when operation is successful
+ * @retval  ESNULLP     when dst/src is NULL POINTER
+ * @retval  ESZEROL     when dmax/smax = ZERO
+ * @retval  ESLEMAX     when dmax > RSIZE_MAX_MEM
+ * @retval  ESNOSPC     when dmax < smax
  *
- *    smax      maximum length of src, in uint16_t
- *
- *    *diff     pointer to the diff which is an integer greater
- *              than, equal to or less than zero according to
- *              whether the object pointed to by dest is
- *              greater than, equal to or less than the object
- *              pointed to by src.
- *
- *  OUTPUT PARAMETERS
- *    none
- *
- * RUNTIME CONSTRAINTS
- *    Neither dest nor src shall be a null pointer.
- *    Neither dmax nor smax shall be zero.
- *    dmax shall not be greater than RSIZE_MAX_MEM.
- *    smax shall not be greater than dmax.
- *
- * RETURN VALUE
- *    EOK        successful operation
- *    ESNULLP    NULL pointer
- *    ESZEROL    zero length
- *    ESLEMAX    length exceeds max limit
- *
- * ALSO SEE
+ * @see 
  *    memcmp_s(), memcmp32_s()
  *
  */

--- a/src/safeclib/memcmp32_s.c
+++ b/src/safeclib/memcmp32_s.c
@@ -34,55 +34,37 @@
 #include "safe_mem_lib.h"
 
 /**
- * NAME
- *    memcmp32_s
- *
- * SYNOPSIS
- *    #include "safe_mem_lib.h"
- *    errno_t
- *    memcmp32_s(const uint32_t *dest, rsize_t dmax,
- *               const uint32_t *src,  rsize_t smax, int *diff)
- *
- * DESCRIPTION
+ * @brief
  *    Compares memory until they differ, and their difference is
  *    returned in diff.  If the block of memory is the same, diff=0.
  *
- * EXTENSION TO
+ * @remark EXTENSION TO
  *    ISO/IEC JTC1 SC22 WG14 N1172, Programming languages, environments
  *    and system software interfaces, Extensions to the C Library,
  *    Part I: Bounds-checking interfaces
  *
- *  INPUT PARAMETERS
- *    dest      pointer to memory to compare against
+ * @param  dest   pointer to memory to compare against
+ * @param  src    pointer to the source memory to compare with dest 
+ * @param  dmax   maximum length of dest, in bytess
+ * @param  smax   length of the source memory block
+ * @param  *diff  pointer to the diff which is an integer greater
+ *                than, equal to or less than zero according to
+ *                whether the object pointed to by dest is
+ *                greater than, equal to or less than the object
+ *                pointed to by src.
  *
- *    dmax      maximum length of dest, in uint32_t
+ * @pre   Neither dest nor src shall be a null pointer.
+ * @pre   Neither dmax nor smax shall be 0.
+ * @pre   dmax shall not be greater than RSIZE_MAX_MEM.
+ * @pre   smax shall not be greater than dmax.
  *
- *    src       pointer to the source memory to compare with dest
+ * @retval  EOK         when operation is successful
+ * @retval  ESNULLP     when dst/src is NULL POINTER
+ * @retval  ESZEROL     when dmax/smax = ZERO
+ * @retval  ESLEMAX     when dmax > RSIZE_MAX_MEM
+ * @retval  ESNOSPC     when dmax < smax
  *
- *    smax      maximum length of src, in uint32_t
- *
- *    *diff     pointer to the diff which is an integer greater
- *              than, equal to or less than zero according to
- *              whether the object pointed to by dest is
- *              greater than, equal to or less than the object
- *              pointed to by src.
- *
- *  OUTPUT PARAMETERS
- *    none
- *
- * RUNTIME CONSTRAINTS
- *    Neither dest nor src shall be a null pointer.
- *    Neither dmax nor smax shall be zero.
- *    dmax shall not be greater than RSIZE_MAX_MEM.
- *    smax shall not be greater than dmax.
- *
- * RETURN VALUE
- *    EOK        successful operation
- *    ESNULLP    NULL pointer
- *    ESZEROL    zero length
- *    ESLEMAX    length exceeds max limit
- *
- * ALSO SEE
+ * @see 
  *    memcmp_s(), memcmp16_s()
  *
  */

--- a/src/safeclib/memcmp_s.c
+++ b/src/safeclib/memcmp_s.c
@@ -35,55 +35,37 @@
 
 
 /**
- * NAME
- *    memcmp_s
- *
- * SYNOPSIS
- *    #include "safe_mem_lib.h"
- *    errno_t
- *    memcmp_s(const void *dest, rsize_t dmax,
- *             const void *src,  rsize_t smax, int *diff)
- *
- * DESCRIPTION
+ * @brief
  *    Compares memory until they differ, and their difference is
  *    returned in diff.  If the block of memory is the same, diff=0.
  *
- * EXTENSION TO
+ * @remark EXTENSION TO
  *    ISO/IEC JTC1 SC22 WG14 N1172, Programming languages, environments
  *    and system software interfaces, Extensions to the C Library,
  *    Part I: Bounds-checking interfaces
  *
- * INPUT PARAMETERS
- *    dest      pointer to memory to compare against
+ * @param  dest   pointer to memory to compare against
+ * @param  src    pointer to the source memory to compare with dest 
+ * @param  dmax   maximum length of dest, in bytess
+ * @param  smax   length of the source memory block
+ * @param  *diff  pointer to the diff which is an integer greater
+ *                than, equal to or less than zero according to
+ *                whether the object pointed to by dest is
+ *                greater than, equal to or less than the object
+ *                pointed to by src.
  *
- *    dmax      maximum length of dest, in bytess
+ * @pre   Neither dest nor src shall be a null pointer.
+ * @pre   Neither dmax nor smax shall be 0.
+ * @pre   dmax shall not be greater than RSIZE_MAX_MEM.
+ * @pre   smax shall not be greater than dmax.
  *
- *    src       pointer to the source memory to compare with dest
+ * @retval  EOK         when operation is successful
+ * @retval  ESNULLP     when dst/src is NULL POINTER
+ * @retval  ESZEROL     when dmax/smax = ZERO
+ * @retval  ESLEMAX     when dmax > RSIZE_MAX_MEM
+ * @retval  ESNOSPC     when dmax < smax
  *
- *    smax      length of the source memory block
- *
- *    *diff     pointer to the diff which is an integer greater
- *              than, equal to or less than zero according to
- *              whether the object pointed to by dest is
- *              greater than, equal to or less than the object
- *              pointed to by src.
- *
- *  OUTPUT PARAMETERS
- *    none
- *
- * RUNTIME CONSTRAINTS
- *    Neither dest nor src shall be a null pointer.
- *    Neither dmax nor smax shall be zero.
- *    dmax shall not be greater than RSIZE_MAX_MEM.
- *    smax shall not be greater than dmax.
- *
- * RETURN VALUE
- *    EOK        successful operation
- *    ESNULLP    NULL pointer
- *    ESZEROL    zero length
- *    ESLEMAX    length exceeds max limit
- *
- * ALSO SEE
+ * @see 
  *    memcmp16_s(), memcmp32_s()
  *
  */

--- a/src/safeclib/memcpy16_s.c
+++ b/src/safeclib/memcpy16_s.c
@@ -36,55 +36,37 @@
 
 
 /**
- * NAME
- *    memcpy16_s
- *
- * SYNOPSIS
- *    #include "safe_mem_lib.h"
- *    errno_t
- *    memcpy16_s(uint16_t *dest, rsize_t dmax,
- *               const uint16_t *src, rsize_t smax)
- *
- * DESCRIPTION
+ * @brief 
  *    This function copies at most smax uint16_ts from src to dest, up to
  *    dmax.
  *
- * EXTENSION TO
+ * @remark EXTENSION TO
  *    ISO/IEC JTC1 SC22 WG14 N1172, Programming languages, environments
  *    and system software interfaces, Extensions to the C Library,
  *    Part I: Bounds-checking interfaces
  *
- * INPUT PARAMETERS
- *    dest      pointer to memory that will be replaced by src.
+ * @param[out] dest   pointer to the memory that will be replaced by src.
+ * @param[in]  dmax   maximum length of the resulting dest, in bytes
+ * @param[in]  src    pointer to the memory that will be copied to dest
+ * @param[in]  smax   maximum number bytes of src that can be copied
  *
- *    dmax      maximum length of the resulting dest
+ * @pre   Neither dest nor src shall be a null pointer.
+ * @pre   Neither dmax nor smax shall be 0.
+ * @pre   dmax shall not be greater than RSIZE_MAX_MEM.
+ * @pre   smax shall not be greater than dmax.
+ * @pre   Copying shall not take place between regions that overlap.
+ *    
+ * @return  If there is a runtime-constraint violation, the memcpy_s function
+ *          stores zeros in the ﬁrst dmax bytes of the region pointed to
+ *          by dest if dest is not a null pointer and smax is valid.
+ * @retval  EOK         when operation is successful
+ * @retval  ESNULLP     when dst/src is NULL POINTER
+ * @retval  ESZEROL     when dmax/smax = ZERO
+ * @retval  ESLEMAX     when dmax > RSIZE_MAX_MEM
+ * @retval  ESNOSPC     when dmax < smax
+ * @retval  ESOVRLP     when src memory overlaps dst
  *
- *    src       pointer to the memory that will be copied to dest
- *
- *    smax      maximum number uint16_t of src to copy
- *
- *
- *  OUTPUT PARAMETERS
- *    dest      is updated
- *
- * RUNTIME CONSTRAINTS
- *    Neither dest nor src shall be a null pointer.
- *    Neither dmax nor smax shall be 0.
- *    dmax shall not be greater than RSIZE_MAX_MEM16.
- *    smax shall not be greater than dmax.
- *    Copying shall not take place between objects that overlap.
- *    If there is a runtime-constraint violation, the memcpy_s function stores
- *      zeros in the ﬁrst dmax bytes of the object pointed to by dest
- *      if dest is not a null pointer and smax is valid.
- *
- * RETURN VALUE
- *    EOK        successful operation
- *    ESNULLP    NULL pointer
- *    ESZEROL    zero length
- *    ESLEMAX    length exceeds max limit
- *    ESOVRLP    source memory overlaps destination
- *
- * ALSO SEE
+ * @see 
  *    memcpy_s(), memcpy32_s(), memmove_s(), memmove16_s(), memmove32_s()
  *
  */

--- a/src/safeclib/memcpy32_s.c
+++ b/src/safeclib/memcpy32_s.c
@@ -36,54 +36,37 @@
 
 
 /**
- * NAME
- *    memcpy32_s
- *
- * SYNOPSIS
- *    #include "safe_mem_lib.h"
- *    errno_t
- *    memcpy32_s(uint32_t *dest, rsize_t dmax,
- *                const uint32_t *src, rsize_t smax)
- *
- * DESCRIPTION
+ * @brief 
  *    This function copies at most smax uint32_ts from src to dest, up to
  *    dmax.
  *
- * EXTENSION TO
+ * @remark EXTENSION TO
  *    ISO/IEC JTC1 SC22 WG14 N1172, Programming languages, environments
  *    and system software interfaces, Extensions to the C Library,
  *    Part I: Bounds-checking interfaces
  *
- * INPUT PARAMETERS
- *    dest      pointer to memory that will be replaced by src.
+ * @param[out] dest   pointer to the memory that will be replaced by src.
+ * @param[in]  dmax   maximum length of the resulting dest, in bytes
+ * @param[in]  src    pointer to the memory that will be copied to dest
+ * @param[in]  smax   maximum number bytes of src that can be copied
  *
- *    dmax      maximum length of the resulting dest
+ * @pre   Neither dest nor src shall be a null pointer.
+ * @pre   Neither dmax nor smax shall be 0.
+ * @pre   dmax shall not be greater than RSIZE_MAX_MEM.
+ * @pre   smax shall not be greater than dmax.
+ * @pre   Copying shall not take place between regions that overlap.
+ *    
+ * @return  If there is a runtime-constraint violation, the memcpy_s function
+ *          stores zeros in the ﬁrst dmax bytes of the region pointed to
+ *          by dest if dest is not a null pointer and smax is valid.
+ * @retval  EOK         when operation is successful
+ * @retval  ESNULLP     when dst/src is NULL POINTER
+ * @retval  ESZEROL     when dmax/smax = ZERO
+ * @retval  ESLEMAX     when dmax > RSIZE_MAX_MEM
+ * @retval  ESNOSPC     when dmax < smax
+ * @retval  ESOVRLP     when src memory overlaps dst
  *
- *    src       pointer to the memory that will be copied to dest
- *
- *    smax      maximum number uint32_t of src to copy
- *
- *  OUTPUT PARAMETERS
- *    dest      is updated
- *
- * RUNTIME CONSTRAINTS
- *    Neither dest nor src shall be a null pointer.
- *    Neither dmax nor smax shall be 0.
- *    dmax shall not be greater than RSIZE_MAX_MEM32.
- *    smax shall not be greater than dmax.
- *    Copying shall not take place between objects that overlap.
- *    If there is a runtime-constraint violation, the memcpy_s function stores
- *      zeros in the ﬁrst dmax bytes of the object pointed to by dest
- *      if dest is not a null pointer and smax is valid.
- *
- * RETURN VALUE
- *    EOK       operation sucessful
- *    ESNULLP   NULL pointer
- *    ESZEROL   length was zero
- *    ESLEMAX   length exceeds max
- *    ESOVRLP   source memory overlaps destination
- *
- * ALSO SEE
+ * @see 
  *    memcpy_s(), memcpy16_s(), memmove_s(), memmove16_s(), memmove32_s()
  *
  */

--- a/src/safeclib/memcpy_s.c
+++ b/src/safeclib/memcpy_s.c
@@ -36,59 +36,42 @@
 
 
 /**
- * NAME
- *    memcpy_s
- *
- * SYNOPSIS
- *    #include "safe_mem_lib.h"
- *    errno_t
- *    memcpy_s(void * restrict dest, rsize_t dmax, const void * restrict src, rsize_t smax)
- *
- * DESCRIPTION
+ * @brief 
  *    This function copies at most smax bytes from src to dest, up to
  *    dmax.
  *
- * SPECIFIED IN
+ * @remark SPECIFIED IN
  *    ISO/IEC JTC1 SC22 WG14 N1172, Programming languages, environments
  *    and system software interfaces, Extensions to the C Library,
  *    Part I: Bounds-checking interfaces
  *
- * INPUT PARAMETERS
- *    dest      pointer to memory that will be replaced by src.
+ * @param[out] dest  pointer to the memory that will be replaced by src.
+ * @param[in]  dmax  maximum length of the resulting dest, in bytes
+ * @param[in]  src   pointer to the memory that will be copied to dest
+ * @param[in]  smax  maximum number bytes of src that can be copied
  *
- *    dmax      maximum length of the resulting dest
+ * @pre  Neither dest nor src shall be a null pointer.
+ * @pre  Neither dmax nor smax shall be 0.
+ * @pre  dmax shall not be greater than RSIZE_MAX_MEM.
+ * @pre  smax shall not be greater than dmax.
+ * @pre  Copying shall not take place between regions that overlap.
+ *    
+ * @return  If there is a runtime-constraint violation, the memcpy_s function
+ *          stores zeros in the ﬁrst dmax bytes of the region pointed to
+ *          by dest if dest is not a null pointer and smax is valid.
+ * @retval  EOK         when operation is successful
+ * @retval  ESNULLP     when dest/src is NULL POINTER
+ * @retval  ESZEROL     when dmax/smax = ZERO
+ * @retval  ESLEMAX     when dmax > RSIZE_MAX_MEM
+ * @retval  ESNOSPC     when dmax < smax
+ * @retval  ESOVRLP     when src memory overlaps dst
  *
- *    src       pointer to the memory that will be copied to dest
- *
- *    smax      maximum number bytes of src to copy
- *
- *  OUTPUT PARAMETERS
- *    dest      is updated
- *
- * RUNTIME CONSTRAINTS
- *    Neither dest nor src shall be a null pointer.
- *    Neither dmax nor smax shall be zero.
- *    dmax shall not be greater than RSIZE_MAX_MEM.
- *    smax shall not be greater than dmax.
- *    Copying shall not take place between regions that overlap.
- *    If there is a runtime-constraint violation, the memcpy_s function
- *        stores zeros in the ﬁrst dmax bytes of the region pointed to
- *        by dest if dest is not a null pointer and smax is valid.
- *
- * RETURN VALUE
- *    EOK        successful operation
- *    ESNULLP    NULL pointer
- *    ESZEROL    zero length
- *    ESLEMAX    length exceeds max limit
- *    ESOVRLP    source memory overlaps destination
- *
- * ALSO SEE
- *    memcpy16_s(), memcpy32_s(), memmove_s(), memmove16_s(),
- *     memmove32_s()
+ * @see 
+ *    memcpy16_s(), memcpy32_s(), memmove_s(), memmove16_s(), memmove32_s()
  *
  */
 errno_t
-memcpy_s(void * restrict dest, rsize_t dmax, const void * restrict src, rsize_t smax)
+memcpy_s (void * restrict dest, rsize_t dmax, const void * restrict src, rsize_t smax)
 {
     uint8_t *dp;
     const uint8_t  *sp;

--- a/src/safeclib/memmove16_s.c
+++ b/src/safeclib/memmove16_s.c
@@ -36,59 +36,42 @@
 
 
 /**
- * NAME
- *    memmove16_s
- *
- * SYNOPSIS
- *    #include "safe_mem_lib.h"
- *    errno_t
- *    memmove16_s(uint16_t *dest, rsize_t dmax,
- *                const uint16_t *src, rsize_t smax)
- *
- * DESCRIPTION
+ * @brief 
  *    The memmove16_s function copies smax uint16_t from the region
- *    pointed to by src into the region pointed to by dest. This
- *    copying takes place as if the smax uint16_t from the region
+ *    pointed to by src into the region pointed to by dest. 
+ * @details
+ *    This copying takes place as if the smax uint16_t from the region
  *    pointed to by src are ﬁrst copied into a temporary array of
  *    smax uint16_t that does not overlap the regions pointed to
  *    by dest or src, and then the smax uint16_t from the temporary
  *    array are copied into the region pointed to by dest.
  *
- * EXTENSION TO
+ * @remark EXTENSION TO
  *    ISO/IEC JTC1 SC22 WG14 N1172, Programming languages, environments
  *    and system software interfaces, Extensions to the C Library,
  *    Part I: Bounds-checking interfaces
  *
- * INPUT PARAMETERS
- *    dest       pointer to the memory that will be replaced by src.
+ * @param[out] dest  pointer to the memory that will be replaced by src.
+ * @param[in]  dmax  maximum length of the resulting dest, in bytes
+ * @param[in]  src   pointer to the memory that will be copied to dest
+ * @param[in]  smax  maximum number bytes of src that can be copied
  *
- *    dmax       maximum length of the resulting dest, in uint16_t
+ * @pre   Neither dest nor src shall be a null pointer.
+ * @pre   Neither dmax nor smax shall be 0.
+ * @pre   dmax shall not be greater than RSIZE_MAX_MEM.
+ * @pre   smax shall not be greater than dmax.
  *
- *    src        pointer to the memory that will be copied
- *               to dest
+ * @return  If there is a runtime-constraint violation, the memmove_s function
+ *          stores zeros in the ﬁrst dmax characters of the region pointed to
+ *          by dest if dest is not a null pointer and dmax is not greater
+ *          than RSIZE_MAX_MEM.
+ * @retval  EOK         when operation is successful
+ * @retval  ESNULLP     when dst/src is NULL POINTER
+ * @retval  ESZEROL     when dmax/smax = ZERO
+ * @retval  ESLEMAX     when dmax > RSIZE_MAX_MEM
+ * @retval  ESNOSPC     when dmax < smax
  *
- *    smax       maximum number uint16_t of src that can be copied
- *
- *  OUTPUT PARAMETERS
- *    dest      is updated
- *
- * RUNTIME CONSTRAINTS
- *    Neither dest nor src shall be a null pointer.
- *    Neither dmax nor smax shall be 0.
- *    dmax shall not be greater than RSIZE_MAX_MEM.
- *    smax shall not be greater than dmax.
- *    If there is a runtime-constraint violation, the memmove_s function
- *      stores zeros in the ﬁrst dmax characters of the regionpointed to
- *      by dest if dest is not a null pointer and dmax is not greater
- *      than RSIZE_MAX_MEM.
- *
- * RETURN VALUE
- *    EOK        successful operation
- *    ESNULLP    NULL pointer
- *    ESZEROL    zero length
- *    ESLEMAX    length exceeds max limit
- *
- * ALSO SEE
+ * @see 
  *    memmove_s(), memmove32_s(), memcpy_s(), memcpy16_s() memcpy32_s()
  *
  */

--- a/src/safeclib/memmove32_s.c
+++ b/src/safeclib/memmove32_s.c
@@ -36,59 +36,42 @@
 
 
 /**
- * NAME
- *    memmove32_s
- *
- * SYNOPSIS
- *    #include "safe_mem_lib.h"
- *    errno_t
- *    memmove32_s(uint32_t *dest, rsize_t dmax,
- *                const uint32_t *src, rsize_t smax)
- *
- * DESCRIPTION
+ * @brief 
  *    The memmove32_s function copies smax uint32_ts from the region
- *    pointed to by src into the region pointed to by dest. This
- *    copying takes place as if the smax uint32_ts from the region
+ *    pointed to by src into the region pointed to by dest. 
+ * @details
+ *    This copying takes place as if the smax uint32_ts from the region
  *    pointed to by src are ﬁrst copied into a temporary array of
  *    smax uint32_ts that does not overlap the regions pointed to
  *    by dest or src, and then the smax uint32_ts from the temporary
  *    array are copied into the region pointed to by dest.
  *
- * EXTENSION TO
+ * @remark EXTENSION TO
  *    ISO/IEC JTC1 SC22 WG14 N1172, Programming languages, environments
  *    and system software interfaces, Extensions to the C Library,
  *    Part I: Bounds-checking interfaces
  *
- * INPUT PARAMETERS
- *    dest       pointer to the memory that will be replaced by src.
+ * @param[out] dest pointer to the memory that will be replaced by src.
+ * @param[in]  dmax   maximum length of the resulting dest, in bytes
+ * @param[in]  src    pointer to the memory that will be copied to dest
+ * @param[in]  smax   maximum number bytes of src that can be copied
  *
- *    dmax       maximum length of the resulting dest, in uint32_t
+ * @pre   Neither dest nor src shall be a null pointer.
+ * @pre   Neither dmax nor smax shall be 0.
+ * @pre   dmax shall not be greater than RSIZE_MAX_MEM.
+ * @pre   smax shall not be greater than dmax.
  *
- *    src        pointer to the memory that will be copied
- *                to dest
+ * @return  If there is a runtime-constraint violation, the memmove_s function
+ *          stores zeros in the ﬁrst dmax characters of the region pointed to
+ *          by dest if dest is not a null pointer and dmax is not greater
+ *          than RSIZE_MAX_MEM.
+ * @retval  EOK         when operation is successful
+ * @retval  ESNULLP     when dst/src is NULL POINTER
+ * @retval  ESZEROL     when dmax/smax = ZERO
+ * @retval  ESLEMAX     when dmax > RSIZE_MAX_MEM
+ * @retval  ESNOSPC     when dmax < smax
  *
- *    smax       maximum number uint32_t of src that can be copied
- *
- *  OUTPUT PARAMETERS
- *    dest      is updated
- *
- * RUNTIME CONSTRAINTS
- *    Neither dest nor src shall be a null pointer.
- *    Neither dmax nor smax shall be 0.
- *    dmax shall not be greater than RSIZE_MAX_MEM.
- *    smax shall not be greater than dmax.
- *    If there is a runtime-constraint violation, the memmove_s function
- *      stores zeros in the ﬁrst dmax characters of the regionpointed to
- *      by dest if dest is not a null pointer and dmax is not greater
- *      than RSIZE_MAX_MEM.
- *
- * RETURN VALUE
- *    EOK        successful operation
- *    ESNULLP    NULL pointer
- *    ESZEROL    zero length
- *    ESLEMAX    length exceeds max limit
- *
- * ALSO SEE
+ * @see 
  *    memmove_s(), memmove16_s(), memcpy_s(), memcpy16_s() memcpy32_s()
  *
  */

--- a/src/safeclib/memmove_s.c
+++ b/src/safeclib/memmove_s.c
@@ -34,63 +34,47 @@
 #include "mem_primitives_lib.h"
 #include "safe_mem_lib.h"
 
-
 /**
- * NAME
- *    memmove_s
+ * @brief 
+ *    The memmove_s function copies smax bytes from the region pointed to by 
+ *    src into the region pointed to by dest. 
+ * @details
+ *    This copying takes place as if the smax bytes from the region pointed 
+ *    to by src are ﬁrst copied into a temporary array of smax bytes that does 
+ *    not overlap the region pointed to by dest or src, and then the smax 
+ *    bytes from the temporary array are copied into the object region to by 
+ *    dest.
  *
- * SYNOPSIS
- *    #include "safe_mem_lib.h"
- *    errno_t
- *    memmove_s(void *dest, rsize_t dmax,
- *              const void *src, rsize_t smax)
- *
- * DESCRIPTION
- *    The memmove_s function copies smax bytes from the region pointed
- *    to by src into the region pointed to by dest. This copying takes place
- *    as if the smax bytes from the region pointed to by src are ﬁrst copied
- *    into a temporary array of smax bytes that does not overlap the region
- *    pointed to by dest or src, and then the smax bytes from the temporary
- *    array are copied into the object region to by dest.
- *
- * SPECIFIED IN
+ * @remark SPECIFIED IN
  *    ISO/IEC TR 24731, Programming languages, environments
  *    and system software interfaces, Extensions to the C Library,
  *    Part I: Bounds-checking interfaces
  *
- * INPUT PARAMETERS
- *    dest       pointer to the memory that will be replaced by src.
+ * @param[out] dest  pointer to the memory that will be replaced by src.
+ * @param[in]  dmax  maximum length of the resulting dest, in bytes
+ * @param[in]  src   pointer to the memory that will be copied to dest
+ * @param[in]  smax  maximum number bytes of src that can be copied
  *
- *    dmax       maximum length of the resulting dest, in bytes
+ * @pre  Neither dest nor src shall be a null pointer.
+ * @pre  Neither dmax nor smax shall be 0.
+ * @pre  dmax shall not be greater than RSIZE_MAX_MEM.
+ * @pre  smax shall not be greater than dmax.
  *
- *    src        pointer to the memory that will be copied
- *                to dest
+ * @return  If there is a runtime-constraint violation, the memmove_s function
+ *          stores zeros in the ﬁrst dmax characters of the region pointed to
+ *          by dest if dest is not a null pointer and dmax is not greater
+ *          than RSIZE_MAX_MEM.
+ * @retval  EOK         when operation is successful
+ * @retval  ESNULLP     when dst/src is NULL POINTER
+ * @retval  ESZEROL     when dmax/smax = ZERO
+ * @retval  ESLEMAX     when dmax > RSIZE_MAX_MEM
+ * @retval  ESNOSPC     when dmax < smax
  *
- *    smax       maximum number bytes of src that can be copied
- *
- *  OUTPUT PARAMETERS
- *    dest      is updated
- *
- * RUNTIME CONSTRAINTS
- *    Neither dest nor src shall be a null pointer.
- *    Neither dmax nor smax shall be 0.
- *    dmax shall not be greater than RSIZE_MAX_MEM.
- *    smax shall not be greater than dmax.
- *    If there is a runtime-constraint violation, the memmove_s function
- *      stores zeros in the ﬁrst dmax characters of the regionpointed to
- *      by dest if dest is not a null pointer and dmax is not greater
- *      than RSIZE_MAX_MEM.
- *
- * RETURN VALUE
- *    EOK        successful operation
- *    ESNULLP    NULL pointer
- *    ESZEROL    zero length
- *    ESLEMAX    length exceeds max limit
- *
- * ALSO SEE
+ * @see 
  *    memmove16_s(), memmove32_s(), memcpy_s(), memcpy16_s() memcpy32_s()
  *
  */
+
 errno_t
 memmove_s (void *dest, rsize_t dmax, const void *src, rsize_t smax)
 {

--- a/src/safeclib/memset16_s.c
+++ b/src/safeclib/memset16_s.c
@@ -37,53 +37,36 @@
 
 
 /**
- * NAME
- *    memset16_s - Sets a block of memory to value
- *
- * SYNOPSIS
- *    #include "safe_mem_lib.h"
- *    errno_t
- *    memset16_s(uint16_t *dest, rsize_t smax, uint16_t value, rsize_t n)
- *
- * DESCRIPTION
+ * @brief
  *    Sets the first n uint16_t values starting at dest to the specified value,
  *    but maximal smax bytes.
  *
- * EXTENSION TO
+ * @remark EXTENSION TO
  *    ISO/IEC JTC1 SC22 WG14 N1172, Programming languages, environments
  *    and system software interfaces, Extensions to the C Library,
  *    Part I: Bounds-checking interfaces
  *
- * INPUT PARAMETERS
- *    dest       pointer to memory that will be set to the value
+ * @param[out]  dest   pointer to memory that will be set to the value
+ * @param[in]   smax   maximum number of bytes to be written
+ * @param[in]   value  byte value to be written
+ * @param[in]   n      number of bytes to be set
  *
- *    smax       maximum number of bytes to be written
+ * @pre  dest shall not be a null pointer.
+ * @pre  smax and n shall not be 0 nor greater than RSIZE_MAX_MEM.
+ * @pre  n shall not be 0 nor greater than RSIZE_MAX_MEM16.
+ * @pre  smax*2 may not be smaller than n.
  *
- *    value      uint16_t value to be written
+ * @return  If there is a runtime-constraints violation, and if dest is not a null
+ *          pointer, and if smax is not larger than RSIZE_MAX_MEM, then, before
+ *          reporting the runtime-constraints violation, memset16_s() copies
+ *          smax bytes to the destination.
+ * @retval  EOK         when operation is successful
+ * @retval  ESNULLP     when dest is NULL POINTER
+ * @retval  ESZEROL     when n = ZERO
+ * @retval  ESLEMAX     when smax or n > RSIZE_MAX_MEM
+ * @retval  ESNOSPC     when smax/2 < n
  *
- *    n          number of uint16_t values to be set
- *
- * OUTPUT PARAMETERS
- *    dest      is updated
- *
- * RUNTIME CONSTRAINTS
- *    dest shall not be a null pointer.
- *    smax shall not be 0 nor greater than RSIZE_MAX_MEM.
- *    n shall not be 0 nor greater than RSIZE_MAX_MEM16.
- *    smax*2 may not be smaller than n.
- *
- *    If there is a runtime-constraints violation, and if dest is not a null
- *    pointer, and if smax is not larger than RSIZE_MAX_MEM, then, before
- *    reporting the runtime-constraints violation, memset16_s() copies
- *    smax bytes to the destination.
- *
- * RETURN VALUE
- *    EOK        successful operation
- *    ESNULLP    NULL pointer
- *    ESZEROL    zero length
- *    ESLEMAX    length exceeds max limit
- *
- * ALSO SEE
+ * @see 
  *    memset_s(), memset32_s()
  *
  */

--- a/src/safeclib/memset32_s.c
+++ b/src/safeclib/memset32_s.c
@@ -37,52 +37,35 @@
 
 
 /**
- * NAME
- *    memset32_s - Sets a block of memory to value
- *
- * SYNOPSIS
- *    #include "safe_mem_lib.h"
- *    errno_t
- *    memset32_s(uint32_t *dest, rsize_t smax, uint32_t value, rsize_t n)
- *
- * DESCRIPTION
+ * @brief
  *    Sets len uint32_t starting at dest to the specified value.
  *
- * EXTENSION TO
+ * @remark EXTENSION TO
  *    ISO/IEC JTC1 SC22 WG14 N1172, Programming languages, environments
  *    and system software interfaces, Extensions to the C Library,
  *    Part I: Bounds-checking interfaces
  *
- * INPUT PARAMETERS
- *    dest       pointer to memory that will be set to the value
+ * @param[out]  dest   pointer to memory that will be set to the value
+ * @param[in]   smax   maximum number of bytes to be written
+ * @param[in]   value  byte value to be written
+ * @param[in]   n      number of bytes to be set
  *
- *    smax       maximum number of bytes to be written
+ * @pre  dest shall not be a null pointer.
+ * @pre  smax and n shall not be 0 nor greater than RSIZE_MAX_MEM.
+ * @pre  n shall not be 0 nor greater than RSIZE_MAX_MEM32.
+ * @pre  smax*4 may not be smaller than n.
  *
- *    value      uint32_t value to be written
+ * @return  If there is a runtime-constraints violation, and if dest is not a null
+ *          pointer, and if smax is not larger than RSIZE_MAX_MEM, then, before
+ *          reporting the runtime-constraints violation, memset32_s() copies
+ *          smax bytes to the destination.
+ * @retval  EOK         when operation is successful
+ * @retval  ESNULLP     when dest is NULL POINTER
+ * @retval  ESZEROL     when n = ZERO
+ * @retval  ESLEMAX     when smax/n > RSIZE_MAX_MEM
+ * @retval  ESNOSPC     when smax/4 < n
  *
- *    n          number of uint32_t values to be written
- *
- * OUTPUT PARAMETERS
- *    dest      is updated
- *
- * RUNTIME CONSTRAINTS
- *    dest shall not be a null pointer.
- *    smax shall not be 0 nor greater than RSIZE_MAX_MEM.
- *    n shall not be 0 nor greater than RSIZE_MAX_MEM32.
- *    smax*4 may not be smaller than n.
- *
- *    If there is a runtime-constraints violation, and if dest is not a null
- *    pointer, and if smax is not larger than RSIZE_MAX_MEM, then, before
- *    reporting the runtime-constraints violation, memset32_s() copies
- *    smax bytes to the destination.
- *
- * RETURN VALUE
- *    EOK        successful operation
- *    ESNULLP    NULL pointer
- *    ESZEROL    zero length
- *    ESLEMAX    length exceeds max limit
- *
- * ALSO SEE
+ * @see 
  *    memset_s(), memset16_s()
  *
  */

--- a/src/safeclib/memset_s.c
+++ b/src/safeclib/memset_s.c
@@ -37,52 +37,35 @@
 
 
 /**
- * NAME
- *    memset_s
- *
- * SYNOPSIS
- *    #include "safe_mem_lib.h"
- *    errno_t
- *    memset_s(void *dest, rsize_t smax, uint8_t value, rsize_t n)
- *
- * DESCRIPTION
+ * @brief
  *    Sets the first n bytes starting at dest to the specified value,
  *    but maximal smax bytes.
  *
- * SPECIFIED IN
+ * @remark SPECIFIED IN
  *    ISO/IEC JTC1 SC22 WG14 N1172, Programming languages, environments
  *    and system software interfaces, Extensions to the C Library,
  *    Part I: Bounds-checking interfaces
  *
- * INPUT PARAMETERS
- *    dest       pointer to memory that will be set to the value
+ * @param[out]  dest   pointer to memory that will be set to the value
+ * @param[in]   smax   maximum number of bytes to be written
+ * @param[in]   value  byte value to be written
+ * @param[in]   n      number of bytes to be set
  *
- *    smax       maximum number of bytes to be written
+ * @pre  dest shall not be a null pointer.
+ * @pre  smax and n shall not be 0 nor greater than RSIZE_MAX_MEM.
+ * @pre  smax may not be smaller than n.
+ *   
+ * @return  If there is a runtime-constraints violation, and if dest is not a null
+ *          pointer, and if smax is not larger than RSIZE_MAX_MEM, then, before
+ *          reporting the runtime-constraints violation, memset_s() copies
+ *          smax bytes to the destination. 
+ * @retval  EOK         when operation is successful
+ * @retval  ESNULLP     when dest is NULL POINTER
+ * @retval  ESZEROL     when n = ZERO
+ * @retval  ESLEMAX     when smax/n > RSIZE_MAX_MEM
+ * @retval  ESNOSPC     when smax < n
  *
- *    value      byte value to be written
- *
- *    n          number of bytes to be set
- *
- * OUTPUT PARAMETERS
- *    dest      is updated
- *
- * RUNTIME CONSTRAINTS
- *    dest shall not be a null pointer.
- *    smax and n shall not be 0 nor greater than RSIZE_MAX_MEM.
- *    smax may not be smaller than n.
-
- *    If there is a runtime-constraints violation, and if dest is not a null
- *    pointer, and if smax is not larger than RSIZE_MAX_MEM, then, before
- *    reporting the runtime-constraints violation, memset_s() copies
- *    smax bytes to the destination.
- *
- * RETURN VALUE
- *    EOK        successful operation
- *    ESNULLP    NULL pointer
- *    ESZEROL    zero length
- *    ESLEMAX    length exceeds max limit
- *
- * ALSO SEE
+ * @see 
  *    memset16_s(), memset32_s()
  *
  */

--- a/src/safeclib/memzero16_s.c
+++ b/src/safeclib/memzero16_s.c
@@ -36,42 +36,27 @@
 
 
 /**
- * NAME
- *    memzero16_s
- *
- * SYNOPSIS
- *    #include "safe_mem_lib.h"
- *    errno_t
- *    memzero16_s(uint16_t *dest, rsize_t len)
- *
- * DESCRIPTION
+ * @brief
  *    Zeros len uint16_ts starting at dest.
  *
- * EXTENSION TO
+ * @remark EXTENSION TO
  *    ISO/IEC JTC1 SC22 WG14 N1172, Programming languages, environments
  *    and system software interfaces, Extensions to the C Library,
  *    Part I: Bounds-checking interfaces
  *
- * INPUT PARAMETERS
- *    dest         pointer to memory to be zeroed.
+ * @param[out] dest  pointer to memory to be zeroed.
+ * @param[in]  len   number of uint16_ts to be zeroed
+
+ * @pre dest shall not be a null pointer.
+ * @pre len shall not be 0 nor greater than RSIZE_MAX_MEM16.
  *
- *    len          number of uint16_ts to be zeroed
+ * @return  If there is a runtime constraint, the operation is not performed.
+ * @retval  EOK         when operation is successful
+ * @retval  ESNULLP     when dest is NULL POINTER
+ * @retval  ESZEROL     when len = ZERO
+ * @retval  ESLEMAX     when len > RSIZE_MAX_MEM16
  *
- * OUTPUT PARAMETERS
- *    dest      is updated
- *
- * RUNTIME CONSTRAINTS
- *    dest shall not be a null pointer.
- *    len shall not be 0 nor greater than RSIZE_MAX_MEM16.
- *    If there is a runtime constraint, the operation is not performed.
- *
- * RETURN VALUE
- *    EOK        successful operation
- *    ESNULLP    NULL pointer
- *    ESZEROL    zero length
- *    ESLEMAX    length exceeds max limit
- *
- * ALSO SEE
+ * @see 
  *    memzero_s(), memzero32_s()
  *
  */

--- a/src/safeclib/memzero32_s.c
+++ b/src/safeclib/memzero32_s.c
@@ -36,42 +36,27 @@
 
 
 /**
- * NAME
- *    memzero32_s
- *
- * SYNOPSIS
- *    #include "safe_mem_lib.h"
- *    errno_t
- *    memzero32_s(uint32_t *dest, rsize_t len)
- *
- * DESCRIPTION
+ * @brief
  *    Zeros len uint32_ts starting at dest.
  *
- * EXTENSION TO
+ * @remark EXTENSION TO
  *    ISO/IEC JTC1 SC22 WG14 N1172, Programming languages, environments
  *    and system software interfaces, Extensions to the C Library,
  *    Part I: Bounds-checking interfaces
  *
- * INPUT PARAMETERS
- *    dest         pointer to memory to be zeroed.
+ * @param[out] dest  pointer to memory to be zeroed.
+ * @param[in]  len   number of uint32_ts to be zeroed
  *
- *    len          number of uint32_ts to be zeroed
+ * @pre dest shall not be a null pointer.
+ * @pre len shall not be 0 nor greater than RSIZE_MAX_MEM32.
  *
- * OUTPUT PARAMETERS
- *    dest      is updated
+ * @return  If there is a runtime constraint, the operation is not performed. 
+ * @retval  EOK         when operation is successful
+ * @retval  ESNULLP     when dest is NULL POINTER
+ * @retval  ESZEROL     when len = ZERO
+ * @retval  ESLEMAX     when len > RSIZE_MAX_MEM32
  *
- * RUNTIME CONSTRAINTS
- *    dest shall not be a null pointer.
- *    len shall not be 0 nor greater than RSIZE_MAX_MEM32.
- *    If there is a runtime constraint, the operation is not performed.
- *
- * RETURN VALUE
- *    EOK        successful operation
- *    ESNULLP    NULL pointer
- *    ESZEROL    zero length
- *    ESLEMAX    length exceeds max limit
- *
- * ALSO SEE
+ * @see 
  *    memzero_s(), memzero16_s()
  *
  */

--- a/src/safeclib/memzero_s.c
+++ b/src/safeclib/memzero_s.c
@@ -36,42 +36,27 @@
 
 
 /**
- * NAME
- *    memzero_s
- *
- * SYNOPSIS
- *    #include "safe_mem_lib.h"
- *    errno_t
- *    memzero_s(void *dest, rsize_t len)
- *
- * DESCRIPTION
+ * @brief
  *    Zeros len bytes starting at dest.
  *
- * EXTENSION TO
+ * @remark EXTENSION TO
  *    ISO/IEC JTC1 SC22 WG14 N1172, Programming languages, environments
  *    and system software interfaces, Extensions to the C Library,
  *    Part I: Bounds-checking interfaces
  *
- * INPUT PARAMETERS
- *    dest         pointer to memory to be zeroed.
+ * @param[out] dest  pointer to memory to be zeroed.
+ * @param[in]  len   number of bytes to be zeroed
  *
- *    len          number of bytes to be zeroed
+ * @pre   dest shall not be a null pointer.
+ * @pre   len shall not be 0 nor greater than RSIZE_MAX_MEM.
  *
- * OUTPUT PARAMETERS
- *    dest      is updated
+ * @return  If there is a runtime constraint, the operation is not performed.
+ * @retval  EOK         when operation is successful
+ * @retval  ESNULLP     when dest is NULL POINTER
+ * @retval  ESZEROL     when len = ZERO
+ * @retval  ESLEMAX     when len > RSIZE_MAX_MEM
  *
- * RUNTIME CONSTRAINTS
- *    dest shall not be a null pointer.
- *    len shall not be 0 nor greater than RSIZE_MAX_MEM.
- *    If there is a runtime constraint, the operation is not performed.
- *
- * RETURN VALUE
- *    EOK        successful operation
- *    ESNULLP    NULL pointer
- *    ESZEROL    zero length
- *    ESLEMAX    length exceeds max limit
- *
- * ALSO SEE
+ * @see 
  *    memzero16_s(), memzero32_s()
  *
  */

--- a/src/safeclib/safe_mem_constraint.c
+++ b/src/safeclib/safe_mem_constraint.c
@@ -39,17 +39,11 @@ static constraint_handler_t mem_handler = NULL;
 
 
 /**
- * NAME
- *    set_mem_constraint_handler_s
- *
- * SYNOPSIS
- *    #include "safe_mem_lib.h"
- *    constraint_handler_t
- *    set_mem_constraint_handler_straint_handler_t handler)
- *
- * DESCRIPTION
+ * @brief
  *    The set_mem_constraint_handler_s function sets the runtime-constraint
- *    handler to be handler. The runtime-constraint handler is the function to
+ *    handler to be handler. 
+ * @details
+ *    The runtime-constraint handler is the function to
  *    be called when a library function detects a runtime-constraint
  *   order:
  *        1.    A pointer to a character string describing the
@@ -66,25 +60,12 @@ static constraint_handler_t mem_handler = NULL;
  *    set_constraint_handler_s is a null pointer, the implementation default
  *    handler becomes the current constraint handler.
  *
- * SPECIFIED IN
+ * @remark SPECIFIED IN
  *    ISO/IEC JTC1 SC22 WG14 N1172, Programming languages, environments
  *    and system software interfaces, Extensions to the C Library,
  *    Part I: Bounds-checking interfaces
  *
- * INPUT PARAMETERS
- *   *msg            Pointer to the message describing the error
- *
- *   *ptr            Pointer to aassociated data.  Can be NULL.
- *
- *    error          The error code encountered.
- *
- * OUTPUT PARAMETERS
- *    none
- *
- * RETURN VALUE
- *    none
- *
- * ALSO SEE
+ * @see
  *    set_str_constraint_handler_s()
  */
 constraint_handler_t
@@ -102,31 +83,12 @@ EXPORT_SYMBOL(set_mem_constraint_handler_s)
 
 
 /**
- * NAME
- *    invoke_safe_mem_constraint_handler
- *
- * SYNOPSIS
- *    #include "safe_mem_constraint.h"
- *    void
- *    invoke_safe_mem_constraint_handler(const char *msg,
- *                                void *ptr,
- *                                errno_t error)
- *
- * DESCRIPTION
+ * @brief
  *    Invokes the currently set constraint handler or the default.
  *
- * INPUT PARAMETERS
- *   *msg            Pointer to the message describing the error
- *
- *   *ptr            Pointer to aassociated data.  Can be NULL.
- *
- *    error          The error code encountered.
- *
- * OUTPUT PARAMETERS
- *    none
- *
- * RETURN VALUE
- *    none
+ * @param *msg    Pointer to the message describing the error
+ * @param *ptr    Pointer to aassociated data. Can be NULL.
+ * @param error  The error code encountered.
  *
  */
 void

--- a/src/safeclib/safe_str_constraint.c
+++ b/src/safeclib/safe_str_constraint.c
@@ -39,17 +39,11 @@ static constraint_handler_t str_handler = NULL;
 
 
 /**
- * NAME
- *    set_str_constraint_handler_s
- *
- * SYNOPSIS
- *    #include "safe_str_lib.h"
- *    constraint_handler_t
- *    set_str_constraint_handler_s(constraint_handler_t handler)
- *
- * DESCRIPTION
+ * @brief
  *    The set_str_constraint_handler_s function sets the runtime-constraint
- *    handler to be handler. The runtime-constraint handler is the function to
+ *    handler to be handler. 
+ * @details
+ *    The runtime-constraint handler is the function to
  *    be called when a library function detects a runtime-constraint
  *    violation. Only the most recent handler registered with
  *    set_str_constraint_handler_s is called when a runtime-constraint
@@ -70,25 +64,12 @@ static constraint_handler_t str_handler = NULL;
  *    set_constraint_handler_s is a null pointer, the implementation default
  *    handler becomes the current constraint handler.
  *
- * SPECIFIED IN
+ * @remark SPECIFIED IN
  *    ISO/IEC JTC1 SC22 WG14 N1172, Programming languages, environments
  *    and system software interfaces, Extensions to the C Library,
  *    Part I: Bounds-checking interfaces
  *
- * INPUT PARAMETERS
- *   *msg            Pointer to the message describing the error
- *
- *   *ptr            Pointer to aassociated data.  Can be NULL.
- *
- *    error          The error code encountered.
- *
- * OUTPUT PARAMETERS
- *    none
- *
- * RETURN VALUE
- *    none
- *
- * ALSO SEE
+ * @see
  *    set_str_constraint_handler_s()
  */
 constraint_handler_t
@@ -106,31 +87,12 @@ EXPORT_SYMBOL(set_str_constraint_handler_s)
 
 
 /**
- * NAME
- *    invoke_safe_str_constraint_handler
- *
- * SYNOPSIS
- *    #include "safe_str_constraint.h"
- *    void
- *    invoke_safe_str_constraint_handler (const char *msg,
- *                                void *ptr,
- *                                errno_t error)
- *
- * DESCRIPTION
+ * @brief
  *    Invokes the currently set constraint handler or the default.
  *
- * INPUT PARAMETERS
- *   *msg            Pointer to the message describing the error
- *
- *   *ptr            Pointer to aassociated data.  Can be NULL.
- *
- *    error          The error code encountered.
- *
- * OUTPUT PARAMETERS
- *    none
- *
- * RETURN VALUE
- *    none
+ * @param *msg    Pointer to the message describing the error
+ * @param *ptr    Pointer to aassociated data. Can be NULL.
+ * @param error  The error code encountered.
  *
  */
 void

--- a/src/safeclib/sprintf_s.c
+++ b/src/safeclib/sprintf_s.c
@@ -4,42 +4,29 @@
 
 
 /** 
- * NAME
- *    sprintf_s
- *
- * SYNOPSIS
- *    #include "safe_str_lib.h"
- *    errno_t 
- *    sprintf_s(char * restrict dest, rsize_t dmax, const char * restrict fmt, ...)
- *
- * DESCRIPTION
+ * @brief
  *    The sprintf_s function composes a string with same test that 
  *    would be printed if format was used on printf. Instead of being 
  *    printed, the content is stored in dest.
- * 
- *    If the buffer dest is too small for the formatted text,
- *    including the terminating null, then the buffer is set to an
- *    empty string by placing a null character at dest[0], and the
- *    invalid parameter handler is invoked. Unlike _snprintf,
- *    sprintf_s guarantees that the buffer will be null-terminated
- *    unless the buffer size is zero.
  *
- * INPUT PARAMETERS
- *    dest        storage location for output buffer.
+ * @param dest  storage location for output buffer.
+ * @param dmax  maximum number of characters to store in buffer.
+ * @param fmt   format-control string.
+ * @param ...   optional arguments
  *
- *    dmax        maximum number of characters to store in buffer.
+ * @return  On success the total number of characters written is returned. 
+ * @return  On failure a negative number is returned. 
+ * @return  If the buffer dest is too small for the formatted text,
+ *          including the terminating null, then the buffer is set to an
+ *          empty string by placing a null character at dest[0], and the
+ *          invalid parameter handler is invoked. Unlike _snprintf,
+ *          sprintf_s guarantees that the buffer will be null-terminated
+ *          unless the buffer size is zero.
+ * @retval  ESNULLP when dest/fmt is NULL pointer
+ * @retval  ESZEROL when dmax = 0
+ * @retval  ESLEMAX when dmax > RSIZE_MAX_STR
+ * @retval  ESNOSPC when return value exceeds dmax
  *
- *    fmt         format-control string.
- *
- *    ...         optional arguments
- *
- * RETURN VALUE
- *    On success the total number of characters written is returned. 
- *
- *    On failure a negative number is returned. 
- *     ESNULLP    NULL pointer
- *     ESZEROL    zero length
- *     ESLEMAX    length exceeds max limit
  */
 
 int sprintf_s(char * restrict dest, rsize_t dmax, const char * restrict fmt, ...)

--- a/src/safeclib/strcasecmp_s.c
+++ b/src/safeclib/strcasecmp_s.c
@@ -35,57 +35,38 @@
 
 
 /**
- * NAME
- *    strcasecmp_s
- *
- * SYNOPSIS
- *    #include "safe_str_lib.h"
- *    errno_t
- *    strcasecmp_s(const char *dest, rsize_t dmax,
- *                 const char *src,  int *indicator)
- *
- * DESCRIPTION
+ * @brief
  *    Case insensitive string comparison by converting
  *    to uppercase prior to the compare.
  *
- * EXTENSION TO
+ * @remark EXTENSION TO
  *    ISO/IEC TR 24731, Programming languages, environments
  *    and system software interfaces, Extensions to the C Library,
  *    Part I: Bounds-checking interfaces
  *
- * INPUT PARAMETERS
- *    dest       pointer to string to compare against
+ * @param[in]   dest       pointer to string to compare against
+ * @param[in]   dmax       restricted maximum length of string dest
+ * @param[in]   src        pointer to the string to be compared to dest
+ * @param[out]  indicator  pointer to result indicator, greater than 0,
+ *                         equal to 0 or less than 0, if the string pointed
+ *                         to by dest is greater than, equal to or less
+ *                         than the string pointed to by src respectively.
  *
- *    dmax       restricted maximum length of string dest
+ * @pre   Neither dest nor src shall be a null pointer.
+ * @pre   indicator shall not be a null pointer.
+ * @pre   dmax shall not be 0
+ * @pre   dmax shall not be greater than RSIZE_MAX_STR
  *
- *    src        pointer to the string to be compared to dest
+ * @return  indicator (when the return code is OK)
+ * @retval  >0 when dest greater than src
+ * @retval  0 when strings the same
+ * @retval  <0 when dest less than src
+ * @retval  EOK          when comparison is complete
+ * @retval  ESNULLP      when dest/src/indicator is NULL pointer
+ * @retval  ESZEROL      when dmax = 0
+ * @retval  ESLEMAX      when dmax > RSIZE_MAX_STR
  *
- *    indicator  pointer to result indicator, greater than 0,
- *               equal to 0 or less than 0, if the string pointed
- *               to by dest is greater than, equal to or less
- *               than the string pointed to by src respectively.
- *
- * OUTPUT PARAMETERS
- *    none
- *
- * RUNTIME CONSTRAINTS
- *    Neither dest nor src shall be a null pointer.
- *    indicator shall not be a null pointer.
- *    dmax shall not be 0
- *    dmax shall not be greater than RSIZE_MAX_STR
- *
- * RETURN VALUE
- *    indicator, when the return code is OK
- *        >0   dest greater than src
- *         0   strings the same
- *        <0   dest less than src
- *
- *    EOK          comparison complete
- *    ESNULLP      pointer was null
- *    ESZEROL      length was zero
- *    ESLEMAX      length exceeded max
- *
- * ALSO SEE
+ * @see
  *    strcmp_s()
  *
  */

--- a/src/safeclib/strcasestr_s.c
+++ b/src/safeclib/strcasestr_s.c
@@ -35,53 +35,34 @@
 
 
 /**
- * NAME
- *    strcasestr_s
- *
- * SYNOPSIS
- *    #include "safe_str_lib.h"
- *    errno_t
- *    strcasestr_s(char *dest, rsize_t dmax,
- *                 const char *src, rsize_t slen, char **substring)
- *
- * DESCRIPTION
+ * @brief
  *    The strcasestr_s() function locates the first occurrence of
  *    the substring pointed to by src which would be located in
  *    the string pointed to by dest.  The comparison is case
  *    insensitive.
  *
- * EXTENSION TO
+ * @remark EXTENSION TO
  *    ISO/IEC TR 24731, Programming languages, environments
  *    and system software interfaces, Extensions to the C Library,
  *    Part I: Bounds-checking interfaces
  *
- * INPUT PARAMETERS
- *    dest      pointer to string to be searched for the substring
+ * @param[in]  dest       pointer to string to be searched for the substring
+ * @param[in]  dmax       restricted maximum length of dest string
+ * @param[in]  src        pointer to the sub string
+ * @param[in]  slen       maximum length of src string
+ * @param[out] substring  returned pointer to the substring
  *
- *    dmax      restricted maximum length of dest string
+ * @pre  Neither dest nor src shall be a null pointer.
+ * @pre  Neither dmax nor slen shall equal zero.
+ * @pre  Neither dmax nor slen shall be greater than RSIZE_MAX_STR.
  *
- *    src       pointer to the sub string
+ * @retval  EOK        when successful operation, substring found.
+ * @retval  ESNULLP    when dst/src/substring is NULL pointer
+ * @retval  ESZEROL    when dmax/slen = 0
+ * @retval  ESLEMAX    when dmax/slen > RSIZE_MAX_STR
+ * @retval  ESNOTFND   when substring not found
  *
- *    slen      maximum length of src string
- *
- *    substring  returned pointer to the substring
- *
- * OUTPUT PARAMETERS
- *     substring  pointer to the substring
- *
- * RUNTIME CONSTRAINTS
- *    Neither dest nor src shall be a null pointer.
- *    Neither dmax nor slen shall equal zero.
- *    Neither dmax nor slen shall be greater than RSIZE_MAX_STR.
- *
- * RETURN VALUE
- *    EOK        successful operation, substring found.
- *    ESNULLP    NULL pointer
- *    ESZEROL    zero length
- *    ESLEMAX    length exceeds max limit
- *    ESNOTFND   substring not found
- *
- * ALSO SEE
+ * @see
  *    strstr_s(), strprefix_s()
  *
  */

--- a/src/safeclib/strcat_s.c
+++ b/src/safeclib/strcat_s.c
@@ -35,65 +35,48 @@
 
 
 /**
- * NAME
- *    strcat_s
- *
- * SYNOPSIS
- *    #include "safe_str_lib.h"
- *    errno_t
- *    strcat_s(char * restrict dest, rsize_t dmax, const char * restrict src)
- *
- * DESCRIPTION
+ * @brief
  *    The strcat_s function appends a copy of the string pointed
  *    to by src (including the terminating null character) to the
  *    end of the string pointed to by dest. The initial character
  *    from src overwrites the null character at the end ofdest.
- *
+ * @details
  *    All elements following the terminating null character (if
  *    any) written by strcat_s in the array of dmax characters
  *    pointed to by dest take unspeciﬁed values when strcat_s
  *    returns.
  *
- * SPECIFIED IN
+ * @remark SPECIFIED IN
  *    ISO/IEC TR 24731, Programming languages, environments
  *    and system software interfaces, Extensions to the C Library,
  *    Part I: Bounds-checking interfaces
  *
- * INPUT PARAMETERS
- *    dest      pointer to string that will be extended by src
- *              if dmax allows. The string is null terminated.
- *              If the resulting concatenated string is less
- *              than dmax, the remaining slack space is nulled.
+ * @param[out]  dest      pointer to string that will be extended by src
+ *                        if dmax allows. The string is null terminated.
+ *                        If the resulting concatenated string is less
+ *                        than dmax, the remaining slack space is nulled.
+ * @param[in]   dmax      restricted maximum length of the resulting dest,
+ *                        including the null
+ * @param[in]   src       pointer to the string that will be concatenaed
+ *                        to string dest
  *
- *    dmax      restricted maximum length of the resulting dest,
- *              including the null
+ * @pre  Neither dest nor src shall be a null pointer
+ * @pre  dmax shall not equal zero
+ * @pre  dmax shall not be greater than RSIZE_MAX_STR
+ * @pre  dmax shall be greater than strnlen_s(src,m).
+ * @pre  Copying shall not takeplace between objects that overlap
  *
- *    src       pointer to the string that will be concatenaed
- *              to string dest
+ * @return  If there is a runtime-constraint violation, then if dest is
+ *          not a null pointer and dmax is greater than zero and not
+ *          greater than RSIZE_MAX_STR, then strcat_s nulls dest.
+ * @retval  EOK        when successful operation, all the characters from src
+ *                     were appended to dest and the result in dest is null terminated.
+ * @retval  ESNULLP    when dest/src is NULL pointer
+ * @retval  ESZEROL    when dmax = 0
+ * @retval  ESLEMAX    when dmax > RSIZE_MAX_STR
+ * @retval  ESUNTERM   when dest not terminated
  *
- * OUTPUT PARAMETERS
- *    dest      is updated
- *
- * RUNTIME CONSTRAINTS
- *    Neither dest nor src shall be a null pointer
- *    dmax shall not equal zero
- *    dmax shall not be greater than RSIZE_MAX_STR
- *    dmax shall be greater than strnlen_s(src,m).
- *    Copying shall not takeplace between objects that overlap
- *    If there is a runtime-constraint violation, then if dest is
- *       not a null pointer and dmax is greater than zero and not
- *       greater than RSIZE_MAX_STR, then strcat_s nulls dest.
- *
- * RETURN VALUE
- *    EOK        successful operation, all the characters from src
- *                were appended to dest and the result in dest is
- *                 null terminated.
- *    ESNULLP    NULL pointer
- *    ESZEROL    zero length
- *    ESLEMAX    length exceeds max
- *    ESUNTERM   dest not terminated
- *
- * ALSO SEE
+ * @see
  *    strncat_s(), strcpy_s(), strncpy_s()
  *
  */

--- a/src/safeclib/strcmp_s.c
+++ b/src/safeclib/strcmp_s.c
@@ -35,56 +35,37 @@
 
 
 /**
- * NAME
- *    strcmp_s
- *
- * Synpsos
- *    #include "safe_str_lib.h"
- *    errno_t
- *    strcmp_s(const char *dest, rsize_t dmax,
- *             const char *src, int *indicator)
- *
- * DESCRIPTION
+ * @brief
  *    Compares string src to string dest.
  *
- * EXTENSION TO
+ * @remark EXTENSION TO
  *    ISO/IEC JTC1 SC22 WG14 N1172, Programming languages, environments
  *    and system software interfaces, Extensions to the C Library,
  *    Part I: Bounds-checking interfaces
  *
- * INPUT PARAMETERS
- *    dest       pointer to string to compare against
+ * @param[in]   dest       pointer to string to compare against
+ * @param[in]   dmax       restricted maximum length of string dest
+ * @param[in]   src        pointer to the string to be compared to dest
+ * @param[out]  indicator  pointer to result indicator, greater than 0,
+ *                         equal to 0 or less than 0, if the string pointed
+ *                         to by dest is greater than, equal to or less
+ *                         than the string pointed to by src respectively.
  *
- *    dmax       restricted maximum length of string dest
+ * @pre   Neither dest nor src shall be a null pointer.
+ * @pre   indicator shall not be a null pointer.
+ * @pre   dmax shall not be 0
+ * @pre   dmax shall not be greater than RSIZE_MAX_STR
  *
- *    src        pointer to the string to be compared to dest
+ * @return  indicator (when the return code is OK)
+ * @retval  >0 when dest greater than src
+ * @retval  0 when strings the same
+ * @retval  <0 when dest less than src
+ * @retval  EOK          when comparison is complete
+ * @retval  ESNULLP      when dest/src/indicator is NULL pointer
+ * @retval  ESZEROL      when dmax = 0
+ * @retval  ESLEMAX      when dmax > RSIZE_MAX_STR
  *
- *    indicator  pointer to result indicator, greater than,
- *               equal to or less than 0, if the string pointed
- *               to by dest is greater than, equal to or less
- *               than the string pointed to by src respectively.
- *
- * OUTPUT PARAMETERS
- *    indicator  updated result indicator
- *
- * RUNTIME CONSTRAINTS
- *    Neither dest nor src shall be a null pointer.
- *    indicator shall not be a null pointer.
- *    dmax shall not be 0
- *    dmax shall not be greater than RSIZE_MAX_STR
- *
- * RETURN VALUE
- *    indicator, when the return code is OK
- *        >0   dest greater than src
- *         0   strings the same
- *        <0   dest less than src
- *
- *    EOK
- *    ESNULLP     pointer was null
- *    ESZEROL     length was zero
- *    ESLEMAX     length exceeded max
- *
- * ALSO SEE
+ * @see
  *    strcasecmp_s()
  *
  */

--- a/src/safeclib/strcmpfld_s.c
+++ b/src/safeclib/strcmpfld_s.c
@@ -35,58 +35,39 @@
 
 
 /**
- * NAME
- *    strcmpfld_s
- *
- * SYNOPSIS
- *    #include "safe_str_lib.h"
- *    errno_t
- *    strcmpfld_s(const char *dest, rsize_t dmax,
- *                const char *src, int *indicator)
- *
- * DESCRIPTION
+ * @brief
  *    Compares the character array pointed to by src to the character array
  *    pointed to by dest for dmax characters.  The null terminator does not
  *    stop the comparison.
  *
- * EXTENSION TO
+ * @remark EXTENSION TO
  *    ISO/IEC TR 24731, Programming languages, environments
  *    and system software interfaces, Extensions to the C Library,
  *    Part I: Bounds-checking interfaces
  *
- * INPUT PARAMETERS
- *    dest       pointer to character array to compare against
+ * @param[in]   dest       pointer to string to compare against
+ * @param[in]   dmax       restricted maximum length of string dest
+ * @param[in]   src        pointer to the string to be compared to dest
+ * @param[out]  indicator  pointer to result indicator, greater than 0,
+ *                         equal to 0 or less than 0, if the string pointed
+ *                         to by dest is greater than, equal to or less
+ *                         than the string pointed to by src respectively.
  *
- *    dmax       restricted maximum length of dest.  The length is
- *                used for the comparison of src against dest.
+ * @pre   Neither dest nor src shall be a null pointer.
+ * @pre   indicator shall not be a null pointer.
+ * @pre   dmax shall not be 0
+ * @pre   dmax shall not be greater than RSIZE_MAX_STR
  *
- *    src        pointer to the character array to be compared to dest
+ * @return  indicator (when the return code is OK)
+ * @retval  >0 when dest greater than src
+ * @retval  0 when strings the same
+ * @retval  <0 when dest less than src
+ * @retval  EOK          when comparison is complete
+ * @retval  ESNULLP      when dest/src/indicator is NULL pointer
+ * @retval  ESZEROL      when dmax = 0
+ * @retval  ESLEMAX      when dmax > RSIZE_MAX_STR
  *
- *    indicator  pointer to result indicator, greater than, equal
- *               to or less than 0, if the character array pointed
- *                to by dest is greater than, equal to or less
- *                than the character array pointed to by src.
- * OUTPUT
- *    indicator  updated result indicator
- *
- * RUNTIME CONSTRAINTS
- *    Neither dest nor src shall be a null pointer.
- *    indicator shall not be a null pointer.
- *    dmax shall not be 0
- *    dmax shall not be greater than RSIZE_MAX_STR
- *
- * RETURN VALUE
- *    indicator, when the return code is OK
- *        >0   dest greater than src
- *         0   strings the same
- *        <0   dest less than src
- *
- *    EOK
- *    ESNULLP     pointer was null
- *    ESZEROL     length was zero
- *    ESLEMAX     length exceeded max
- *
- * ALSO SEE
+ * @see
  *    strcpyfld_s(), strcpyfldin_s(), strcpyfldout_s()
  *
  */

--- a/src/safeclib/strcpy_s.c
+++ b/src/safeclib/strcpy_s.c
@@ -35,15 +35,7 @@
 
 
 /**
- * NAME
- *    strcpy_s
- *
- * SYNOPSIS
- *    #include "safe_str_lib.h"
- *    errno_t
- *    strcpy_s(char * restrict dest, rsize_t dmax, const char * restrict src)
- *
- * DESCRIPTION
+ * @brief
  *    The strcpy_s function copies the string pointed to by src
  *    (including the terminating null character) into the array
  *    pointed to by dest. All elements following the terminating
@@ -51,42 +43,33 @@
  *    of dmax characters pointed to by dest are nulled when
  *    strcpy_s returns.
  *
- * SPECIFIED IN
+ * @remark SPECIFIED IN
  *    ISO/IEC TR 24731, Programming languages, environments
  *    and system software interfaces, Extensions to the C Library,
  *    Part I: Bounds-checking interfaces
  *
- * INPUT PARAMETERS
- *    dest      pointer to string that will be replaced by src.
+ * @param[out]  dest  pointer to string that will be replaced by src.
+ * @param[in]   dmax  restricted maximum length of dest
+ * @param[in]   src   pointer to the string that will be copied to dest
  *
- *    dmax      restricted maximum length of dest
+ * @pre Neither dest nor src shall be a null pointer.
+ * @pre dmax shall not be greater than RSIZE_MAX_STR.
+ * @pre dmax shall not equal zero.
+ * @pre dmax shall be greater than strnlen_s(src, dmax).
+ * @pre Copying shall not take place between objects that overlap.
  *
- *    src       pointer to the string that will be copied
- *               to dest
+ * @return  If there is a runtime-constraint violation, then if dest
+ *          is not a null pointer and destmax is greater than zero and
+ *          not greater than RSIZE_MAX_STR, then strcpy_s nulls dest.
+ * @retval  EOK        when successful operation, the characters in src were
+ *                     copied into dest and the result is null terminated.
+ * @retval  ESNULLP    when dest/src is NULL pointer
+ * @retval  ESZEROL    when dmax = 0
+ * @retval  ESLEMAX    when dmax > RSIZE_MAX_STR
+ * @retval  ESOVRLP    when strings overlap
+ * @retval  ESNOSPC    when dest < src
  *
- * OUTPUT PARAMETERS
- *    dest      updated
- *
- * RUNTIME CONSTRAINTS
- *    Neither dest nor src shall be a null pointer.
- *    dmax shall not be greater than RSIZE_MAX_STR.
- *    dmax shall not equal zero.
- *    dmax shall be greater than strnlen_s(src, dmax).
- *    Copying shall not take place between objects that overlap.
- *    If there is a runtime-constraint violation, then if dest
- *       is not a null pointer and destmax is greater than zero and
- *       not greater than RSIZE_MAX_STR, then strcpy_s nulls dest.
- *
- * RETURN VALUE
- *    EOK        successful operation, the characters in src were
- *               copied into dest and the result is null terminated.
- *    ESNULLP    NULL pointer
- *    ESZEROL    zero length
- *    ESLEMAX    length exceeds max limit
- *    ESOVRLP    strings overlap
- *    ESNOSPC    not enough space to copy src
- *
- * ALSO SEE
+ * @see
  *    strcat_s(), strncat_s(), strncpy_s()
  *
  */

--- a/src/safeclib/strcpyfld_s.c
+++ b/src/safeclib/strcpyfld_s.c
@@ -35,57 +35,40 @@
 
 
 /**
- * NAME
- *    strcpyfld_s
- *
- * SYNOPSIS
- *    #include "safe_str_lib.h"
- *    errno_t
- *    strcpyfld_s(char *dest, rsize_t dmax, const char *src, rsize_t slen)
- *
- * DESCRIPTION
+ * @brief
  *    The strcpyfld_s function copies slen characters from the character
  *    array pointed to by src into the character array pointed to by dest.
  *    The copy operation does not stop on the null character as the
  *    function copies slen characters.
  *
- * EXTENSION TO
+ * @remark EXTENSION TO
  *    ISO/IEC TR 24731-1, Programming languages, environments
  *    and system software interfaces, Extensions to the C Library,
  *    Part I: Bounds-checking interfaces
  *
- * INPUT PARAMETERS
- *    dest      pointer to character array that will be replaced by src.
+ * @param[out]  dest  pointer to string that will be replaced by src.
+ * @param[in]   dmax  restricted maximum length of dest
+ * @param[in]   src   pointer to the character array that will be copied to dest
+ * @param[in]   slen  maximum length of src
  *
- *    dmax      restricted maximum length of dest
+ * @pre  Neither dest nor src shall be a null pointer.
+ * @pre  dmax shall not equal zero.
+ * @pre  dmax shall not be greater than RSIZE_MAX_STR.
+ * @pre  slen shall not equal zero.
+ * @pre  slen shall not exceed dmax
+ * @pre  Copying shall not take place between objects that overlap.
+ *    
+ * @return  If there is a runtime-constraint violation, then if dest
+ *          is not a null pointer and destmax is greater than zero and
+ *          not greater than RSIZE_MAX_STR, then strcpyfld_s nulls dest.
+ * @retval  EOK        when successful operation
+ * @retval  ESNULLP    when dest/src is NULL pointer
+ * @retval  ESZEROL    when dmax/slen = 0
+ * @retval  ESLEMAX    when dmax > RSIZE_MAX_STR
+ * @retval  ESOVRLP    when strings overlap
+ * @retval  ESNOSPC    when dmax < slen
  *
- *    src       pointer to the character array that will be copied
- *              to dest
- *
- *    slen      maximum length of src
- *
- * OUTPUT PARAMETERS
- *    dest      updated
- *
- * RUNTIME CONSTRAINTS
- *    Neither dest nor src shall be a null pointer.
- *    dmax shall not equal zero.
- *    dmax shall not be greater than RSIZE_MAX_STR.
- *    slen shall not equal zero.
- *    slen shall not exceed dmax
- *    Copying shall not take place between objects that overlap.
- *    If there is a runtime-constraint violation, then if dest
- *       is not a null pointer and destmax is greater than zero and
- *       not greater than RSIZE_MAX_STR, then strcpyfld_s nulls dest.
- *
- * RETURN VALUE
- *    EOK        successful operation
- *    ESNULLP    NULL pointer
- *    ESZEROL    zero length
- *    ESLEMAX    length exceeds max limit
- *    ESOVRLP    strings overlap
- *
- * ALSO SEE
+ * @see
  *    strcpyfldin_s(), strcpyfldout_s()
  *
  */

--- a/src/safeclib/strcpyfldin_s.c
+++ b/src/safeclib/strcpyfldin_s.c
@@ -35,59 +35,42 @@
 
 
 /**
- * NAME
- *    strcpyfldin_s
- *
- * SYNOPSIS
- *    #include "safe_str_lib.h"
- *    errno_t
- *    strcpyfldin_s(char *dest, rsize_t dmax,
- *                  const char *src, rsize_t slen)
- *
- * DESCRIPTION
+ * @brief
  *    The strcpyfldin_s function copies at most slen characters from the
  *    null terminated string pointed to by src into the fixed character
  *    array pointed to by dest. The copy operation stops on the  null
  *    character if encountered and then continues to fill the field
  *    with nulls up to dmax characters.
  *
- * EXTENSION TO
+ * @remark EXTENSION TO
  *    ISO/IEC TR 24731-1, Programming languages, environments
  *    and system software interfaces, Extensions to the C Library,
  *    Part I: Bounds-checking interfaces
  *
- * INPUT PARAMETERS
- *    dest      pointer to character array that will be replaced by src.
+ * @param[out]  dest  pointer to string that will be replaced by src.
+ * @param[in]   dmax  restricted maximum length of dest
+ * @param[in]   src   pointer to the null terminated string that will be copied
+ *                    into the character array pointed to by dest
+ * @param[in]   slen  maximum length of src
  *
- *    dmax      restricted maximum length of dest
+ * @pre  Neither dest nor src shall be a null pointer.
+ * @pre  dmax shall not equal zero.
+ * @pre  dmax shall not be greater than RSIZE_MAX_STR.
+ * @pre  slen shall not equal zero.
+ * @pre  slen shall not exceed dmax
+ * @pre  Copying shall not take place between objects that overlap.
  *
- *    src       pointer to the null terminated string that will be copied
- *               into the character array pointed to by dest
+ * @return  If there is a runtime-constraint violation, then if dest
+ *          is not a null pointer and dmax is greater than zero and
+ *          not greater than RSIZE_MAX_STR, then strcpyfldin_s nulls dest
+ * @retval  EOK        when successful operation
+ * @retval  ESNULLP    when dest/src is NULL pointer
+ * @retval  ESZEROL    when dmax/slen = 0
+ * @retval  ESLEMAX    when dmax > RSIZE_MAX_STR
+ * @retval  ESOVRLP    when strings overlap
+ * @retval  ESNOSPC    when dmax < slen
  *
- *    slen      length of source
- *
- * OUTPUT PARAMETERS
- *    dest      updated
- *
- * RUNTIME CONSTRAINTS
- *    Neither dest nor src shall be a null pointer.
- *    dmax shall not equal zero.
- *    dmax shall not be greater than RSIZE_MAX_STR.
- *    slen shall not equal zero.
- *    slen shall not exceed dmax
- *    Copying shall not take place between objects that overlap.
- *    If there is a runtime-constraint violation, then if dest
- *       is not a null pointer and dmax is greater than zero and
- *       not greater than RSIZE_MAX_STR, then strcpyfldin_s nulls dest.
- *
- * RETURN VALUE
- *    EOK        successful operation
- *    ESNULLP    NULL pointer
- *    ESZEROL    zero length
- *    ESLEMAX    length exceeds max limit
- *    ESOVRLP    strings overlap
- *
- * ALSO SEE
+ * @see
  *    strcpyfld_s(), strcpyfldout_s(),
  *
  */

--- a/src/safeclib/strcpyfldout_s.c
+++ b/src/safeclib/strcpyfldout_s.c
@@ -35,16 +35,7 @@
 
 
 /**
- * NAME
- *    strcpyfldout_s
- *
- * SYNOPSIS
- *    #include "safe_str_lib.h"
- *    errno_t
- *    strcpyfldout_s(char *dest, rsize_t dmax,
- *                   const char *src, rsize_t slen)
- *
- * DESCRIPTION
+ * @brief
  *    The strcpyfldout_s function copies slen characters from
  *    the character array pointed to by src into the string
  *    pointed to by dest. A null is included to properly
@@ -52,44 +43,35 @@
  *    stop on the null character as function copies dmax
  *    characters.
  *
- * EXTENSION TO
+ * @remark EXTENSION TO
  *    ISO/IEC TR 24731, Programming languages, environments
  *    and system software interfaces, Extensions to the C Library,
  *    Part I: Bounds-checking interfaces
  *
- * INPUT PARAMETERS
- *    dest      pointer to string that will be replaced by src.
+ * @param[out]  dest  pointer to string that will be replaced by src.
+ * @param[in]   dmax  restricted maximum length of dest
+ * @param[in]   src   pointer to the character array to be copied
+ *                    to dest and null terminated.
+ * @param[in]   slen  the maximum number of characters that will be
+ *                    copied from the src field into the dest string.
  *
- *    dmax      restricted maximum length of dest
+ * @pre  Neither dest nor src shall be a null pointer.
+ * @pre  dmax shall not equal zero.
+ * @pre  dmax shall not be greater than RSIZE_MAX_STR.
+ * @pre  slen shall not equal zero.
+ * @pre  slen shall not exceed dmax
+ * @pre  Copying shall not take place between objects that overlap.
  *
- *    src       pointer to the character array to be copied
- *              to dest and null terminated.
- *
- *    slen      the maximum number of characters that will be
- *              copied from the src field into the dest string.
- *
- * OUTPUT PARAMETERS
- *    dest      updated
- *
- * RUNTIME CONSTRAINTS
- *    Neither dest nor src shall be a null pointer.
- *    dmax shall not equal zero.
- *    dmax shall not be greater than RSIZE_MAX_STR.
- *    slen shall not equal zero.
- *    slen shall not exceed dmax
- *    Copying shall not take place between objects that overlap.
- *    If there is a runtime-constraint violation, then if dest
- *       is not a null pointer and dmax is greater than zero and
- *       not greater than RSIZE_MAX_STR, then strcpyfldout_s nulls dest.
- *
- * RETURN VALUE
- *    EOK        successful operation
- *    ESNULLP    NULL pointer
- *    ESZEROL    zero length
- *    ESLEMAX    length exceeds max limit
- *    ESOVRLP    strings overlap
- *
- * ALSO SEE
+ * @return  If there is a runtime-constraint violation, then if dest
+ *          is not a null pointer and dmax is greater than zero and
+ *          not greater than RSIZE_MAX_STR, then strcpyfldout_s nulls dest
+ * @retval  EOK        when successful operation
+ * @retval  ESNULLP    when dest/src is NULL pointer
+ * @retval  ESZEROL    when dmax/slen = 0
+ * @retval  ESLEMAX    when dmax > RSIZE_MAX_STR
+ * @retval  ESOVRLP    when strings overlap
+ * @retval  ESNOSPC    when dmax < slen
+ * @see
  *    strcpyfld_s(), strcpyfldin_s()
  *
  */

--- a/src/safeclib/strcspn_s.c
+++ b/src/safeclib/strcspn_s.c
@@ -35,16 +35,7 @@
 
 
 /**
- * NAME
- *    strcspn_s
- *
- * SYNOPSIS
- *    #include "safe_str_lib.h"
- *    errno_t
- *    strcspn_s(const char *dest, rsize_t dmax,
- *              const char *src,  rsize_t slen, rsize_t *count)
- *
- * DESCRIPTION
+ * @brief
  *    This function computes the prefix length of the string pointed
  *    to by dest which consists entirely of characters that are
  *    excluded from the string pointed to by src. The scanning stops
@@ -52,39 +43,29 @@
  *    exclusion string is checked to the null or after slen
  *    characters.
  *
- * EXTENSION TO
+ * @remark EXTENSION TO
  *    ISO/IEC TR 24731, Programming languages, environments
  *    and system software interfaces, Extensions to the C Library,
  *    Part I: Bounds-checking interfaces
  *
- * INPUT PARAMETERS
- *    dest     pointer to string to determine the prefix
+ * @param[in]   dest   pointer to string to determine the prefix
+ * @param[in]   dmax   restricted maximum length of string dest
+ * @param[in]   src    pointer to exclusion string
+ * @param[in]   slen   restricted maximum length of string src
+ * @param[out]  count  pointer to a count variable that will be updated
+ *                     with the dest substring length
  *
- *    dmax     restricted maximum length of string dest
+ * @pre  Neither dest nor src shall be a null pointer.
+ * @pre  count shall not be a null pointer.
+ * @pre  dmax shall not be 0
+ * @pre  dmax shall not be greater than RSIZE_MAX_STR
  *
- *    src      pointer to exclusion string
- *
- *    slen     restricted maximum length of string src
- *
- *    count    pointer to a count variable that will be updated
- *              with the dest substring length
- *
- * OUTPUT PARAMETERS
- *    count    updated count variable
- *
- * RUNTIME CONSTRAINTS
- *    Neither dest nor src shall be a null pointer.
- *    count shall not be a null pointer.
- *    dmax shall not be 0
- *    dmax shall not be greater than RSIZE_MAX_STR
- *
- * RETURN VALUE
- *    EOK         count
- *    ESNULLP     NULL pointer
- *    ESZEROL     zero length
- *    ESLEMAX     length exceeds max limit
- *
- * ALSO SEE
+ * @retval  EOK         when operation is successful
+ * @retval  ESNULLP     when dest/src/count is NULL pointer
+ * @retval  ESZEROL     when dmax/slen = 0 
+ * @retval  ESLEMAX     when dmax/slen > RSIZE_MAX_STR
+ * 
+ * @see
  *    strspn_s(), strpbrk_s(), strstr_s()
  *
  */

--- a/src/safeclib/strfirstchar_s.c
+++ b/src/safeclib/strfirstchar_s.c
@@ -35,51 +35,33 @@
 
 
 /**
- * NAME
- *    strfirstchar_s
- *
- * SYNOPSIS
- *    #include "safe_str_lib.h"
- *    errno_t
- *    strfirstchar_s(char *dest, rsize_t dmax, char c, char **first)
- *
- * DESCRIPTION
+ * @brief
  *    This function returns a pointer to the first occurrence
  *    of character c in dest. The scanning stops at the first null
  *    or after dmax characters.
  *
- * EXTENSION TO
+ * @remark EXTENSION TO
  *    ISO/IEC TR 24731, Programming languages, environments
  *    and system software interfaces, Extensions to the C Library,
  *    Part I: Bounds-checking interfaces
  *
- * INPUT PARAMETERS
- *    dest    pointer to string to compare against
+ * @param[in]   dest   pointer to string to compare against
+ * @param[in]   dmax   restricted maximum length of string
+ * @param[in]   c      character to locate
+ * @param[out]  first  returned pointer to first occurrence of c
  *
- *    dmax    restricted maximum length of string
+ * @pre  dest shall not be a null pointer.
+ * @pre  first shall not be a null pointer.
+ * @pre  dmax shall not be 0
+ * @pre  dmax shall not be greater than RSIZE_MAX_STR
  *
- *    c       character to locate
+ * @return  pointer to first occurence of c, NULL if not found
+ * @retval  EOK         when pointer to first occurrence is returned
+ * @retval  ESNULLP     when dst/first is NULL pointer
+ * @retval  ESZEROL     when dmax = 0
+ * @retval  ESLEMAX     when dmax > RSIZE_MAX_STR
  *
- *    first   returned pointer to first occurrence of c
- *
- * OUTPUT PARAMETERS
- *    first   updated pointer to first occurrence of c
- *
- * RUNTIME CONSTRAINTS
- *    dest shall not be a null pointer.
- *    first shall not be a null pointer.
- *    dmax shall not be 0
- *    dmax shall not be greater than RSIZE_MAX_STR
- *
- * RETURN VALUE
- *    pointer to first occurence of c, NULL if not found
- *
- *    EOK         pointer to first occurrence is returned
- *    ESNULLP     NULL pointer
- *    ESZEROL     zero length
- *    ESLEMAX     length exceeds max limit
- *
- * ALSO SEE
+ * @see
  *    strlastchar_s(), strfirstdiff_s(), strfirstsame_s(),
  *    strlastdiff_s(), strlastsame_s(),
  *

--- a/src/safeclib/strfirstdiff_s.c
+++ b/src/safeclib/strfirstdiff_s.c
@@ -35,54 +35,35 @@
 
 
 /**
- * NAME
- *    strfirstdiff_s
- *
- * SYNOPSIS
- *    #include "safe_str_lib.h"
- *    errno_t
- *    strfirstdiff_s(const char *dest, rsize_t dmax,
- *                   const char *src, rsize_t *index)
- *
- * DESCRIPTION
+ * @brief
  *    Returns the index of the first character that is different
  *    between dest and src. Index is valid only for OK.
  *    The scanning stops at the first null in dest or src, or
  *    after dmax characters.
  *
- * EXTENSION TO
+ * @remark EXTENSION TO
  *    ISO/IEC TR 24731, Programming languages, environments
  *    and system software interfaces, Extensions to the C Library,
  *    Part I: Bounds-checking interfaces
  *
- * INPUT PARAMETERS
- *    dest     pointer to string to compare against
+ * @param[in]   dest   pointer to string to compare against
+ * @param[in]   dmax   restricted maximum length of string dest
+ * @param[in]   src    pointer to the string to be compared to dest
+ * @param[out]  index  pointer to returned index to first difference
  *
- *    dmax     restricted maximum length of string dest
+ * @pre  Neither dest nor src shall be a null pointer.
+ * @pre  indicator shall not be a null pointer.
+ * @pre  dmax shall not be 0.
+ * @pre  dmax shall not be greater than RSIZE_MAX_STR.
  *
- *    src      pointer to the string to be compared to dest
+ * @return  index to first difference, when the return code is OK
+ * @retval  EOK         when index to first diff is returned
+ * @retval  ESNODIFF    when no difference
+ * @retval  ESNULLP     when dest/src/index is NULL pointer
+ * @retval  ESZEROL     when dmax = 0
+ * @retval  ESLEMAX     when dmax > RSIZE_MAX_STR
  *
- *    index    pointer to returned index to first difference
- *
- * OUTPUT PARAMETERS
- *    index    returned index to first difference
- *
- * RUNTIME CONSTRAINTS
- *    Neither dest nor src shall be a null pointer.
- *    indicator shall not be a null pointer.
- *    dmax shall not be 0.
- *    dmax shall not be greater than RSIZE_MAX_STR.
- *
- * RETURN VALUE
- *    index to first difference, when the return code is OK
- *
- *    EOK         index to first diff is returned
- *    ESNODIFF    no difference
- *    ESNULLP     NULL pointer
- *    ESZEROL     zero length
- *    ESLEMAX     length exceeds max limit
- *
- * ALSO SEE
+ * @see
  *    strfirstchar_s(), strfirstsame_s(), strlastchar_s(),
  *    strlastdiff_s(), strlastsame_s()
  *

--- a/src/safeclib/strfirstsame_s.c
+++ b/src/safeclib/strfirstsame_s.c
@@ -35,53 +35,34 @@
 
 
 /**
- * NAME
- *    strfirstsame_s
- *
- * SYNOPSIS
- *    #include "safe_str_lib.h"
- *    errno_t
- *    strfirstsame_s(const char *dest, rsize_t dmax,
- *                   const char *src,  rsize_t *index)
- *
- * DESCRIPTION
+ * @brief
  *    Returns the index of the first character that is the
  *    same between dest and src.  The scanning stops at the
  *    fisrt null in dest or src, or after dmax characters.
  *
- * EXTENSION TO
+ * @remark EXTENSION TO
  *    ISO/IEC TR 24731, Programming languages, environments
  *    and system software interfaces, Extensions to the C Library,
  *    Part I: Bounds-checking interfaces
  *
- * INPUT PARAMETERS
- *    dest     pointer to string to compare against
+ * @param[in]   dest   pointer to string to compare against
+ * @param[in]   dmax   restricted maximum length of string dest
+ * @param[in]   src    pointer to the string to be compared to dest
+ * @param[out]  index  pointer to returned index
  *
- *    dmax     restricted maximum length of string dest
+ * @pre  Neither dest nor src shall be a null pointer.
+ * @pre  indicator shall not be a null pointer.
+ * @pre  dmax shall not be 0.
+ * @pre  dmax shall not be greater than RSIZE_MAX_STR.
  *
- *    src      pointer to the string to be compared to dest
+ * @return  index to first same char, when the return code is OK
+ * @retval  EOK         when index to first same char is returned
+ * @retval  ESNULLP     when dst/src/index is NULL pointer
+ * @retval  ESZEROL     when dmax = 0
+ * @retval  ESLEMAX     when dmax > RSIZE_MAX_STR
+ * @retval  ESNOTFND    when not found
  *
- *    index    pointer to returned index
- *
- * OUTPUT PARAMETERS
- *    index    updated index
- *
- * RUNTIME CONSTRAINTS
- *    Neither dest nor src shall be a null pointer.
- *    indicator shall not be a null pointer.
- *    dmax shall not be 0
- *    dmax shall not be greater than RSIZE_MAX_STR
- *
- * RETURN VALUE
- *    index to first same char, when the return code is OK
- *
- *    EOK         index to first same char is returned
- *    ESNULLP     NULL pointer
- *    ESZEROL     zero length
- *    ESLEMAX     length exceeds max limit
- *    ESNOTFND    not found
- *
- * ALSO SEE
+ * @see
  *    strfirstchar_s(), strfirstdiff_s(), strlastchar_s(),
  *    strlastdiff_s(), strlastsame_s()
  *

--- a/src/safeclib/strisalphanumeric_s.c
+++ b/src/safeclib/strisalphanumeric_s.c
@@ -35,42 +35,28 @@
 
 
 /**
- * NAME
- *    strisalphanumeric_s
- *
- * SYNOPSIS
- *    #include "safe_dest_lib.h"
- *    bool
- *    strisalphanumeric_s(const char *dest, rsize_t dmax)
- *
- * DESCRIPTION
+ * @brief
  *    This function checks if the entire string contains
  *    alphanumerics.  The scanning stops at the first null
  *    or after dmax characters.
  *
- * EXTENSION TO
+ * @remark EXTENSION TO
  *    ISO/IEC TR 24731, Programming languages, environments
  *    and system software interfaces, Extensions to the C Library,
  *    Part I: Bounds-checking interfaces
  *
- * INPUT PARAMETERS
- *    dest         pointer to string
+ * @param dest  pointer to string
+ * @param dmax  maximum length of string
  *
- *    dmax         maximum length of string
  *
- * OUTPUT PARAMETERS
- *    none
+ * @pre  dest shall not be a null pointer.
+ * @pre  dmax shall not equal zero.
+ * @pre  dmax shall not be greater than RSIZE_MAX_STR.
  *
- * Runtime-condestaints
- *    dest shall not be a null pointer.
- *    dmax shall not equal zero.
- *    dmax shall not be greater than RSIZE_MAX_STR.
+ * @return  true   when dest is alphanumeric
+ * @return  false  when dest is not alphanumeric or an error occurred
  *
- * RETURN VALUE
- *    true      dest is alphanumeric
- *    false     dest is not alphanumeric or an error occurred
- *
- * ALSO SEE
+ * @see
  *    strisascii_s(), strisdigit_s(), strishex_s(), strislowercase_s(),
  *    strismixedcase_s(), strisuppercase_s()
  *

--- a/src/safeclib/strisascii_s.c
+++ b/src/safeclib/strisascii_s.c
@@ -34,47 +34,31 @@
 #include "safe_str_lib.h"
 
 
-/*
- *-
- * NAME
- *    strisascii_s
- *
- * SYNOPSIS
- *    #include "safe_str_lib.h"
- *    bool
- *    strisascii_s(const char *dest, rsize_t dmax)
- *
- * DESCRIPTION
+/**
+ * @brief
  *    This function checks if the entire string contains ascii
  *    characters.  The scanning stops at the first null or
  *    at most dmax characters.
  *
- * EXTENSION TO
+ * @remark EXTENSION TO
  *    ISO/IEC TR 24731, Programming languages, environments
  *    and system software interfaces, Extensions to the C Library,
  *    Part I: Bounds-checking interfaces
  *
- * INPUT PARAMETERS
- *    dest       pointer to string
+ * @param  dest  pointer to string
+ * @param  dmax  maximum length of string
  *
- *    dmax       maximum length of string
+ * @pre  dest shall not be a null pointer.
+ * @pre  dmax shall not equal zero.
+ * @pre  dmax shall not be greater than RSIZE_MAX_STR.
  *
- * OUTPUT PARAMETERS
- *    none
+ * @return  true   when string is ascii
+ * @return  false  when string contains one or more non-ascii or an error occurred
  *
- * RUNTIME CONSTRAINTS
- *    dest shall not be a null pointer.
- *    dmax shall not equal zero.
- *    dmax shall not be greater than RSIZE_MAX_STR.
- *
- * RETURN VALUE
- *    true, string is ascii
- *    false, string contains one or more non-ascii or an error occurred
- *
- * ALSO SEE
+ * @see
  *    strisalphanumeric_s(), strisdigit_s(), strishex_s(),
  *    strislowercase_s(), strismixedcase_s(), strisuppercase_s()
- *-
+ *
  */
 bool
 strisascii_s (const char *dest, rsize_t dmax)

--- a/src/safeclib/strisdigit_s.c
+++ b/src/safeclib/strisdigit_s.c
@@ -35,41 +35,26 @@
 
 
 /**
- * NAME
- *    strisdigit_s
- *
- * SYNOPSIS
- *    #include "safe_str_lib.h"
- *    bool
- *    strisdigit_s(const char *dest, rsize_t dmax)
- *
- * DESCRIPTION
+ * @brief
  *    This function checks that the entire string contains digits.
  *    The scanning stops at the first null or after dmax characters.
  *
- * EXTENSION TO
+ * @remark EXTENSION TO
  *    ISO/IEC TR 24731, Programming languages, environments
  *    and system software interfaces, Extensions to the C Library,
  *    Part I: Bounds-checking interfaces
  *
- * INPUT PARAMETERS
- *    dest        pointer to string
+ * @param  dest  pointer to string
+ * @param  dmax  maximum length of string
  *
- *    dmax        maximum length of string
+ * @pre  dest shall not be a null pointer.
+ * @pre  dmax shall not equal zero.
+ * @pre  dmax shall not be greater than RSIZE_MAX_STR..
  *
- * OUTPUT PARAMETERS
- *    none
+ * @return  true      when string is digit
+ * @return  false     when string is not digit or an error occurred
  *
- * RUNTIME CONSTRAINTS
- *    dest shall not be a null pointer.
- *    dmax shall not equal zero.
- *    dmax shall not be greater than RSIZE_MAX_STR.
- *
- * RETURN VALUE
- *    true      string is digit
- *    false     string is not digit or an error occurred
- *
- * ALSO SEE
+ * @see
  *    strisalphanumeric_s(), strisascii_s(), strishex_s(),
  *    strislowercase_s(), strismixedcase_s(), strisuppercase_s()
  *

--- a/src/safeclib/strishex_s.c
+++ b/src/safeclib/strishex_s.c
@@ -35,42 +35,27 @@
 
 
 /**
- * NAME
- *    strishex_s
- *
- * SYNOPSIS
- *    #include "safe_str_lib.h"
- *    bool
- *    strishex_s(const char *dest, rsize_t dmax)
- *
- * DESCRIPTION
+ * @brief
  *    This function checks that the entire string contains
  *    hex characters.  The scanning stops at the first null
  *    or after dmax characters.
  *
- * EXTENSION TO
+ * @remark EXTENSION TO
  *    ISO/IEC TR 24731, Programming languages, environments
  *    and system software interfaces, Extensions to the C Library,
  *    Part I: Bounds-checking interfaces
  *
- * INPUT PARAMETERS
- *    dest       pointer to string
+ * @param  dest  pointer to string
+ * @param  dmax  maximum length of string
  *
- *    dmax       maximum length of string
+ * @pre  dest shall not be a null pointer.
+ * @pre  dmax shall not equal zero.
+ * @pre  dmax shall not be greater than RSIZE_MAX_STR.
  *
- * OUTPUT PARAMETERS
- *    none
+ * @return  true   when string is hex
+ * @return  false  when string is not hex or an error occurred
  *
- * RUNTIME CONSTRAINTS
- *    dest shall not be a null pointer.
- *    dmax shall not equal zero.
- *    dmax shall not be greater than RSIZE_MAX_STR.
- *
- * RETURN VALUE
- *    true      string is hex
- *    false     string is not hex or an error occurred
- *
- * ALSO SEE
+ * @see
  *    strisalphanumeric_s(), strisascii_s(), strisdigit_s(),
  *    strislowercase_s(), strismixedcase_s(),
  *    strisuppercase_s()

--- a/src/safeclib/strislowercase_s.c
+++ b/src/safeclib/strislowercase_s.c
@@ -35,43 +35,29 @@
 
 
 /**
- * NAME
- *    strislowercase_s
- *
- * SYNOPSIS
- *    #include "safe_str_lib.h"
- *    bool
- *    strislowercase_s(const char *dest, rsize_t dmax)
- *
- * DESCRIPTION
+ * @brief
  *    This function checks if entire string is lowercase.
  *    The scanning stops at the first null or after dmax
  *    characters.
  *
- * EXTENSION TO
+ * @remark EXTENSION TO
  *    ISO/IEC TR 24731, Programming languages, environments
  *    and system software interfaces, Extensions to the C Library,
  *    Part I: Bounds-checking interfaces
  *
- * INPUT PARAMETERS
- *    dest      pointer to string
+ * @param  dest  pointer to string
+ * @param  dmax  maximum length of string
  *
- *    dmax      maximum length of string
+ * @pre  dest shall not be a null pointer.
+ * @pre  dest shall be a null terminated.
+ * @pre  dmax shall not equal zero.
+ * @pre  dmax shall not be greater than RSIZE_MAX_STR.
  *
- * OUTPUT PARAMETERS
- *    none
  *
- * RUNTIME CONSTRAINTS
- *    dest shall not be a null pointer.
- *    dest shal be null terminated.
- *    dmax shall not equal zero.
- *    dmax shall not be greater than RSIZE_MAX_STR.
+ * @return  true   when string is lowercase
+ * @return  false  when string is not lowercase or an error occurred
  *
- * RETURN VALUE
- *    true      string is lowercase
- *    false     string is not lowercase or an error occurred
- *
- * ALSO SEE
+ * @see
  *    strisalphanumeric_s(), strisascii_s(), strisdigit_s(),
  *    strishex_s(), strismixedcase_s(),
  *    strisuppercase_s()

--- a/src/safeclib/strismixedcase_s.c
+++ b/src/safeclib/strismixedcase_s.c
@@ -35,42 +35,28 @@
 
 
 /**
- * NAME
- *    strismixedcase_s
- *
- * SYNOPSIS
- *    #include "safe_str_lib.h"
- *    bool
- *    strismixedcase_s(const char *dest, rsize_t dmax)
- *
- * DESCRIPTION
+ * @brief
  *    This function checks that the entire string is mixed
  *    case.  The scanning stops at the first null or after
  *    dmax characters.
  *
- * EXTENSION TO
+ * @remark EXTENSION TO
  *    ISO/IEC TR 24731, Programming languages, environments
  *    and system software interfaces, Extensions to the C Library,
  *    Part I: Bounds-checking interfaces
  *
- * INPUT PARAMETERS
- *    dest       pointer to string
+ * @param  dest  pointer to string
+ * @param  dmax  maximum length of string
  *
- *    dmax       maximum length of string
+ * @pre  dest shall not be a null pointer.
+ * @pre  dmax shall not equal zero.
+ * @pre  dmax shall not be greater than RSIZE_MAX_STR.
  *
- * OUTPUT PARAMETERS
- *    none
  *
- * RUNTIME CONSTRAINTS
- *    dest shall not be a null pointer.
- *    dmax shall not equal zero.
- *    dmax shall not be greater than RSIZE_MAX_STR.
+ * @return  true   when string is mixed case
+ * @return  false  when string is not mixed case or error
  *
- * RETURN VALUE
- *    true       string is mixed case
- *    false      string is not mixed case or error
- *
- * ALSO SEE
+ * @see
  *    strisalphanumeric_s(), strisascii_s(), strisdigit_s(),
  *    strishex_s(), strislowercase_s(),
  *    strisuppercase_s()

--- a/src/safeclib/strispassword_s.c
+++ b/src/safeclib/strispassword_s.c
@@ -35,47 +35,34 @@
 
 
 /**
- * NAME
- *    strispassword_s
- *
- * SYNOPSIS
- *    #include "strlib.h"
- *    bool
- *    strispassword_s(const char *dest, rsize_t dmax)
- *
- * DESCRIPTION
+ * @brief
  *    This function validates the make-up of a password string.
- *    -SAFE_STR_PASSWORD_MIN_LENGTH character minimum
- *    -SAFE_STR_PASSWORD_MAX_LENGTH character maximum
- *    -at least SAFE_STR_MIN_LOWERCASE lower case characters
- *    -at least SAFE_STR_MIN_UPPERCASE upper case characters
- *    -at least SAFE_STR_MIN_NUMBERS number
- *    -at least SAFE_STR_MIN_SPECIALS special
+ * @details
+ *       -Password must have mininmum SAFE_STR_PASSWORD_MIN_LENGTH characters 
+ *    \n -Password can have maximum SAFE_STR_PASSWORD_MAX_LENGTH characters
+ *    \n -Password must have at least SAFE_STR_MIN_LOWERCASE lower case characters
+ *    \n -Password must have at least SAFE_STR_MIN_UPPERCASE upper case characters
+ *    \n -Password must have at least SAFE_STR_MIN_NUMBERS numbers
+ *    \n -Password must have at least SAFE_STR_MIN_SPECIALS special characters
  *
- * EXTENSION TO
+ * @remark EXTENSION TO
  *    ISO/IEC TR 24731, Programming languages, environments
  *    and system software interfaces, Extensions to the C Library,
  *    Part I: Bounds-checking interfaces
  *
- * INPUT PARAMETERS
- *    dest       pointer to string
+ * @param  dest  pointer to string
+ * @param  dmax  maximum length of password string
  *
- *    dmax       length of password string
  *
- * OUTPUT PARAMETERS
- *    none
+ * @pre  dest shall not be a null pointer.
+ * @pre  dmax > SAFE_STR_PASSWORD_MIN_LENGTH
+ * @pre  dmax < SAFE_STR_PASSWORD_MAX_LENGTH
+ * @pre  dest shall not be unterminated
  *
- * RUNTIME CONSTRAINTS
- *    dest shall not be a null pointer.
- *    length > SAFE_STR_PASSWORD_MIN_LENGTH
- *    length < SAFE_STR_PASSWORD_MAX_LENGTH
- *    dest shall not be unterminated
+ * @return  true   when string has valid password makeup
+ * @return  false  when string does not meet requirements or an error occurred
  *
- * RETURN VALUE
- *    true, string has valid password makeup
- *    false, string does not meet requirements or an error occurred
- *
- * ALSO SEE
+ * @see
  *    strzero_s()
  *
  */

--- a/src/safeclib/strisuppercase_s.c
+++ b/src/safeclib/strisuppercase_s.c
@@ -35,42 +35,28 @@
 
 
 /**
- * NAME
- *    strisuppercase_s
- *
- * SYNOPSIS
- *    #include "safe_str_lib.h"
- *    bool
- *    strisuppercase_s(const char *dest, rsize_t dmax)
- *
- * DESCRIPTION
+ * @brief
  *    This function checks if entire string is uppercase
  *    The scanning stops at the first null or after dmax
  *    characters.
  *
- * EXTENSION TO
+ * @remark EXTENSION TO
  *    ISO/IEC TR 24731, Programming languages, environments
  *    and system software interfaces, Extensions to the C Library,
  *    Part I: Bounds-checking interfaces
  *
- * INPUT PARAMETERS
- *    dest      pointer to string
+ * @param  dest  pointer to string
+ * @param  dmax  maximum length of string
  *
- *    dmax      maximum length of string
+ * @pre  dest shall not be a null pointer.
+ * @pre  dmax shall not equal zero.
+ * @pre  dmax shall not be greater than RSIZE_MAX_STR.
  *
- * OUTPUT PARAMETERS
- *    none
  *
- * RUNTIME CONSTRAINTS
- *    dest shall not be a null pointer.
- *    dmax shall not equal zero.
- *    dmax shall not be greater than RSIZE_MAX_STR.
+ * @return  true   when string is uppercase
+ * @return  false  when string is not uppercase or an error occurred
  *
- * RETURN VALUE
- *    true      string is uppercase
- *    false     string is not uppercase or an error occurred
- *
- * ALSO SEE
+ * @see
  *    strisalphanumeric_s(), strisascii_s(), strisdigit_s(),
  *    strishex_s(), strislowercase_s(), strismixedcase_s(),
  *

--- a/src/safeclib/strlastchar_s.c
+++ b/src/safeclib/strlastchar_s.c
@@ -35,52 +35,33 @@
 
 
 /**
- * NAME
- *    strlastchar_s
- *
- * SYNOPSIS
- *    #include "safe_str_lib.h"
- *    errno_t
- *    strlastchar_s(char *dest, rsize_t dmax, char c, char **last)
- *
- * DESCRIPTION
+ * @brief
  *    Returns a pointer to the last occurrence of character c in
  *    dest.  The scanning stops at the first null or after dmax
  *    characters.
  *
- * EXTENSION TO
+ * @remark EXTENSION TO
  *    ISO/IEC TR 24731, Programming languages, environments
  *    and system software interfaces, Extensions to the C Library,
  *    Part I: Bounds-checking interfaces
  *
- * INPUT PARAMETERS
- *    dest    pointer to string
+ * @param[in]   dest  pointer to string to compare against
+ * @param[in]   dmax  restricted maximum length of string
+ * @param[in]   c     character to locate
+ * @param[out]  last  returned pointer to first occurrence of c
  *
- *    dmax    restricted maximum length of string
+ * @pre  dest shall not be a null pointer.
+ * @pre  last shall not be a null pointer.
+ * @pre  dmax shall not be 0
+ * @pre  dmax shall not be greater than RSIZE_MAX_STR
  *
- *    c       character to locate
+ * @return  pointer to last occurence of c, NULL if not found
+ * @retval  EOK         when pointer to last occurrence is returned
+ * @retval  ESNULLP     when dst/first is NULL pointer
+ * @retval  ESZEROL     when dmax = 0
+ * @retval  ESLEMAX     when dmax > RSIZE_MAX_STR
  *
- *    last    returned pointer to last occurrence
- *
- * OUTPUT PARAMETERS
- *    last    updated pointer to last occurrence
- *
- * RUNTIME CONSTRAINTS
- *    dest shall not be a null pointer.
- *    last shall not be a null pointer.
- *    dmax shall not be 0
- *    dmax shall not be greater than RSIZE_MAX_STR
- *
- * RETURN VALUE
- *    pointer to the last occurrence, when the return code is OK
- *
- *    EOK         pointer to the last occurence is returned
- *    ESNOTFND    c not found in dest
- *    ESNULLP     NULL pointer
- *    ESZEROL     zero length
- *    ESLEMAX     length exceeds max limit
- *
- * ALSO SEE
+ * @see
  *    strfirstchar_s(), strfirstdiff_s(), strfirstsame_s(),
  *    strlastdiff_s(), strlastsame_s()
  *

--- a/src/safeclib/strlastdiff_s.c
+++ b/src/safeclib/strlastdiff_s.c
@@ -35,54 +35,35 @@
 
 
 /**
- * NAME
- *    strlastdiff_s
- *
- * SYNOPSIS
- *    #include "safe_str_lib.h"
- *    errno_t
- *    strlastdiff_s(const char *dest, rsize_t dmax,
- *                  const char *src, rsize_t *index)
- *
- * DESCRIPTION
+ * @brief
  *    Returns the index of the last character that is different
  *    between dest and src.  Index is valid only for EOK.
  *    The scanning stops at the first null in dest or src, or
  *    after dmax characters.
  *
- * EXTENSION TO
+ * @remark EXTENSION TO
  *    ISO/IEC TR 24731, Programming languages, environments
  *    and system software interfaces, Extensions to the C Library,
  *    Part I: Bounds-checking interfaces
  *
- * INPUT PARAMETERS
- *    dest    pointer to string to compare against
+ * @param[in]   dest   pointer to string to compare against
+ * @param[in]   dmax   restricted maximum length of string dest
+ * @param[in]   src    pointer to the string to be compared to dest
+ * @param[out]  index  pointer to returned index to last difference
  *
- *    dmax    restricted maximum length of string dest
+ * @pre  Neither dest nor src shall be a null pointer.
+ * @pre  indicator shall not be a null pointer.
+ * @pre  dmax shall not be 0.
+ * @pre  dmax shall not be greater than RSIZE_MAX_STR.
  *
- *    src     pointer to the string to be compared to dest
+ * @return  index to last difference, when the return code is OK
+ * @retval  EOK         when index to last diff is returned
+ * @retval  ESNODIFF    when no difference
+ * @retval  ESNULLP     when dest/src/index is NULL pointer
+ * @retval  ESZEROL     when dmax = 0
+ * @retval  ESLEMAX     when dmax > RSIZE_MAX_STR
  *
- *    index   pointer to returned index of last difference
- *
- * OUTPUT PARAMETERS
- *    index   updated index of last difference
- *
- * RUNTIME CONSTRAINTS
- *    Neither dest nor src shall be a null pointer.
- *    indicator shall not be a null pointer.
- *    dmax shall not be 0
- *    dmax shall not be greater than RSIZE_MAX_STR
- *
- * RETURN VALUE
- *    index to last difference, when the return code is OK
- *
- *    EOK         index to last diff is returned
- *    ESNODIFF    no difference
- *    ESNULLP     NULL pointer
- *    ESZEROL     zero length
- *    ESLEMAX     length exceeds max limit
- *
- * ALSO SEE
+ * @see
  *    strfirstchar_s(), strfirstdiff_s(), strfirstsame_s(),
  *    strlastchar_s(), strlastsame_s()
  *

--- a/src/safeclib/strlastsame_s.c
+++ b/src/safeclib/strlastsame_s.c
@@ -35,54 +35,34 @@
 
 
 /**
- * NAME
- *    strlastsame_s
- *
- * SYNOPSIS
- *    #include "safe_str_lib.h"
- *    errno_t
- *    strlastsame_s(const char *dest, rsize_t dmax,
- *                  const char *src, rsize_t *index)
- *
- * DESCRIPTION
+ * @brief
  *    Returns the index of the last character that is the
  *    same between dest and src. The scanning stops at the
  *    first nul in dest or src, or after dmax characters.
  *
- * EXTENSION TO
+ * @remark EXTENSION TO
  *    ISO/IEC TR 24731, Programming languages, environments
  *    and system software interfaces, Extensions to the C Library,
  *    Part I: Bounds-checking interfaces
  *
- * INPUT PARAMETERS
- *    dest      pointer to string to compare against
+ * @param[in]   dest   pointer to string to compare against
+ * @param[in]   dmax   restricted maximum length of string dest
+ * @param[in]   src    pointer to the string to be compared to dest
+ * @param[out]  index  pointer to returned index
  *
- *    dmax    restricted maximum length of string dest
+ * @pre  Neither dest nor src shall be a null pointer.
+ * @pre  indicator shall not be a null pointer.
+ * @pre  dmax shall not be 0.
+ * @pre  dmax shall not be greater than RSIZE_MAX_STR.
  *
- *    src      pointer to the string to be compared to dest
+ * @return  index to last same char, when the return code is OK
+ * @retval  EOK         when index to last same char is returned
+ * @retval  ESNULLP     when dst/src/index is NULL pointer
+ * @retval  ESZEROL     when dmax = 0
+ * @retval  ESLEMAX     when dmax > RSIZE_MAX_STR
+ * @retval  ESNOTFND    when not found
  *
- *    index   pointer to returned index
- *
- * OUTPUT PARAMETERS
- *    index   updated index
- *
- * RUNTIME CONSTRAINTS
- *    Neither dest nor src shall not be a null pointer.
- *    indicator shall not be a null pointer.
- *    dmax shall not be 0
- *    dmax shall not be greater than RSIZE_MAX_STR
- *
- * RETURN VALUE
- *    index to last same char, when the return code is OK
- *
- *    EOK         index to last same char is returned
- *    ESNULLP     NULL pointer
- *    ESZEROL     zero length
- *    ESLEMAX     length exceeds max limit
- *    ESNOTFND    not found
- *    ESUNTERM    string unterminated
- *
- * ALSO SEE
+ * @see
  *    strfirstchar_s(), strfirstdiff_s(), strfirstsame_s(),
  *    strlastchar_s(), strlastdiff_s()
  *

--- a/src/safeclib/strljustify_s.c
+++ b/src/safeclib/strljustify_s.c
@@ -35,50 +35,35 @@
 
 
 /**
- * NAME
- *    strljustify_s
- *
- * SYNOPSIS
- *    #include "safe_str_lib.h"
- *    errno_t
- *    strljustify_s(char *dest, rsize_t dmax)
- *
- * DESCRIPTION
+ * @brief 
  *    Removes beginning whitespace from the string pointed to by
  *    dest by shifting the text left over writting the beginning
- *    whitespace, left justifying the text.  The left justified
- *    text is null terminated.
- *
+ *    whitespace, left justifying the text.  
+ * @details
+ *    The left justified text is null terminated.
  *    The text is shifted so the original pointer can continue
  *    to be used.
  *
- * EXTENSION TO
+ * @remark EXTENSION TO
  *    ISO/IEC JTC1 SC22 WG14 N1172, Programming languages, environments
  *    and system software interfaces, Extensions to the C Library,
  *    Part I: Bounds-checking interfaces
  *
- * INPUT PARAMETERS
- *    dest    pointer to string to left justify
+ * @param[out]  dest  pointer to string to left justify
+ * @param[in]   dmax  restricted maximum length of string
  *
- *    dmax    restricted maximum length of string
+ * @pre  dest shall not be a null pointer.
+ * @pre  dmax shall not be 0
+ * @pre  dmax shall not be greater than RSIZE_MAX_STR
+ * @pre  dest shall be null terminated
  *
- * OUTPUT PARAMETERS
- *    dest    left justified
+ * @retval  EOK         when successful operation
+ * @retval  ESNULLP     when dest is NULL pointer
+ * @retval  ESZEROL     when dmax = 0
+ * @retval  ESLEMAX     when dmax > RSIZE_MAX_STR
+ * @retval  ESUNTERM    when dest was not null terminated
  *
- * RUNTIME CONSTRAINTS
- *    dest shall not be a null pointer.
- *    dmax shall not be 0
- *    dmax shall not be greater than RSIZE_MAX_STR
- *    dest shall be null terminated
- *
- * RETURN VALUE
- *    EOK
- *    ESNULLP     NULL pointer
- *    ESZEROL     zero length
- *    ESLEMAX     length exceeds max limit
- *    ESUNTERM    dest was not null terminated
- *
- * ALSO SEE
+ * @see
  *    strremovews_s(),
  *
  */

--- a/src/safeclib/strncat_s.c
+++ b/src/safeclib/strncat_s.c
@@ -35,66 +35,47 @@
 
 
 /**
- * NAME
- *    strncat_s
- *
- * SYNOPSIS
- *    #include "safe_str_lib.h"
- *    errno_t
- *    strncat_s(char * restrict dest, rsize_t dmax, const char * restrict src, rsize_t slen)
- *
- * DESCRIPTION
+ * @brief
  *    The strncat_s function appends a copy of the string pointed
  *    to by src (including the terminating null character) to the
  *    end of the string pointed to by dest. The initial character
  *    from src overwrites the null character at the end of dest.
- *
+ * @details
  *    All elements following the terminating null character (if
  *    any) written by strncat_s in the array of dmax characters
  *    pointed to by dest take unspeciﬁed values when strncat_s returns.
  *
- * SPECIFIED IN
+ * @remark SPECIFIED IN
  *    ISO/IEC TR 24731, Programming languages, environments
  *    and system software interfaces, Extensions to the C Library,
  *    Part I: Bounds-checking interfaces
  *
- * INPUT PARAMETERS
- *    dest      pointer to string that will be extended by src
- *              if dmax allows. The string is null terminated.
- *              If the resulting concatenated string is less
- *              than dmax, the remaining slack space is nulled.
+ * @param[out]  dest  pointer to string that will be extended by src
+ *                    if dmax allows. The string is null terminated.
+ *                    If the resulting concatenated string is less
+ *                    than dmax, the remaining slack space is nulled.
+ * @param[in]   dmax  restricted maximum length of the resulting dest,
+ *                    including the null
+ * @param[in]   src   pointer to the string that will be concatenaed
+ *                    to string dest
+ * @param[in]   slen  maximum characters to append
  *
- *    dmax      restricted maximum length of the resulting dest,
- *              including the null
- *
- *    src       pointer to the string that will be concatenaed
- *              to string dest
- *
- *    slen      maximum characters to append
- *
- * OUTPUT PARAMETERS
- *    dest      updated string
- *
- * RUNTIME CONSTRAINTS
- *    Neither dest nor src shall be a null pointer
- *    dmax shall not equal zero
- *    dmax shall not be greater than RSIZE_STR_MAX
- *    dmax shall be greater than strnlen_s(src,m).
- *    Copying shall not takeplace between objects that overlap
- *    If there is a runtime-constraint violation, then if dest is
- *       not a null pointer and dmax is greater than zero and not
- *       greater thanRSIZE_MAX, then strncat_s sets dest[0] to the
- *       null character.
- *
- * RETURN VALUE
- *     EOK        successful operation, all the characters from src
- *                   were appended to dest and the result in dest is
- *                   null terminated.
- *     ESNULLP    NULL pointer
- *     ESZEROL    zero length
- *     ESLEMAX    length exceeds max limit
- *     ESUNTERM   dest not terminated
- *
+ * @pre  Neither dest nor src shall be a null pointer
+ * @pre  dmax shall not equal zero
+ * @pre  dmax shall not be greater than RSIZE_MAX_STR
+ * @pre   dmax shall be greater than strnlen_s(src,m).
+ * @pre   Copying shall not takeplace between objects that overlap
+ *  
+ * @returns  If there is a runtime-constraint violation, then if dest is
+ *           not a null pointer and dmax is greater than zero and not
+ *           greater than RSIZE_MAX, then strncat_s sets dest[0] to the
+ *           null character. 
+ * @retval  EOK        successful operation, all the characters from src
+ *                     null terminated.
+ * @retval  ESNULLP    when dest/src is NULL pointer
+ * @retval  ESZEROL    when dmax/slen = 0
+ * @retval  ESLEMAX    when dmax/slen > RSIZE_MAX_STR
+ * @retval  ESUNTERM   when dest not terminated
  *
  */
 errno_t

--- a/src/safeclib/strncpy_s.c
+++ b/src/safeclib/strncpy_s.c
@@ -34,71 +34,50 @@
 #include "safe_str_lib.h"
 
 
-/*
- * NAME
- *    strncpy_s
- *
- * SYNOPSIS
- *    #include "safe_str_lib.h"
- *    errno_t
- *    strncpy_s(char * restrict dest, rsize_t dmax, const char * restrict src, rsize_t slen)
- *
- * DESCRIPTION
+/**
+ * @brief
  *    The strncpy_s function copies not more than slen successive characters
  *    (characters that follow a null character are not copied) from the
  *    array pointed to by src to the array pointed to by dest. If no null
  *    character was copied from src, then dest[n] is set to a null character.
- *
+ * @details
  *    All elements following the terminating null character (if any)
  *    written by strncpy_s in the array of dmax characters pointed to
  *    by dest take on the null value when strncpy_s returns.
  *
- * Specicified in:
+ * @remark SPECIFIED IN
  *    ISO/IEC TR 24731-1, Programming languages, environments
  *    and system software interfaces, Extensions to the C Library,
  *    Part I: Bounds-checking interfaces
  *
- * INPUT PARAMETERS
- *    dest      pointer to string that will be replaced by src.
- *              The resulting string is null terminated.
+ * @param[out]  dest  pointer to string that will be replaced by src.
+ * @param[in]   dmax  restricted maximum length of dest
+ * @param[in]   src   pointer to the string that will be copied to dest
+ * @param[in]   slen  the maximum number of characters to copy from src
  *
- *    dmax      restricted maximum length of the resulting dest,
- *              including the null
+ * @pre  Neither dmax nor slen shall be equal to zero.
+ * @pre  Neither dmax nor slen shall be equal zero.
+ * @pre  Neither dmax nor slen shall be greater than RSIZE_MAX_STR.
+ * @pre  If slen is either greater than or equal to dmax, then dmax should be more than strnlen_s(src,dmax)
+ * @pre  Copying shall not take place between objects that overlap.
  *
- *    src       pointer to the string that will be copied
- *              to string dest
+ * @return  If there is a runtime-constraint violation, then if dest
+ *          is not a null pointer and dmax greater than RSIZE_MAX_STR,
+ *          then strncpy_s nulls dest.
+ * @retval  EOK        successful operation, the characters in src were copied
+ *                     to dest and the result is null terminated.
+ * @retval  ESNULLP    when dest/src is NULL pointer
+ * @retval  ESZEROL    when dmax/slen = 0
+ * @retval  ESLEMAX    when dmax/slen > RSIZE_MAX_STR
+ * @retval  ESOVRLP    when strings overlap
+ * @retval  ESNOSPC    when dest < src
  *
- *    slen      the maximum number of characters to copy from src
- *
- * OUTPUT PARAMETERS
- *    dest      updated with src string
- *
- * RUNTIME CONSTRAINTS
- *    Neither dmax nor slen shall be equal to zero.
- *    Neither dmax nor slen shall be equal zero.
- *    Neither dmax nor slen shall be greater than RSIZE_MAX_STR.
- *    If slen is either greater than or equal to dmax, then dmax
- *     should be more than strnlen_s(src,dmax)
- *    Copying shall not take place between objects that overlap.
- *    If there is a runtime-constraint violation, then if dest
- *       is not a null pointer and dmax greater than RSIZE_MAX_STR,
- *       then strncpy_s nulls dest.
- *
- * RETURN VALUE
- *    EOK        successful operation, the characters in src were copied
- *                  to dest and the result is null terminated.
- *    ESNULLP    NULL pointer
- *    ESZEROL    zero length
- *    ESLEMAX    length exceeds max limit
- *    ESOVRLP    strings overlap
- *    ESNOSPC    not enough space to copy src
- *
- * ALSO SEE
+ * @see
  *    strcat_s(), strncat_s(), strcpy_s()
- *-
+ *
  */
 errno_t
-strncpy_s(char * restrict dest, rsize_t dmax, const char * restrict src, rsize_t slen)
+strncpy_s (char * restrict dest, rsize_t dmax, const char * restrict src, rsize_t slen)
 {
     rsize_t orig_dmax;
     char *orig_dest;

--- a/src/safeclib/strnlen_s.c
+++ b/src/safeclib/strnlen_s.c
@@ -35,47 +35,31 @@
 
 
 /**
- * NAME
- *    strnlen_s
- *
- * SYNOPSIS
- *    #include "safe_str_lib.h"
- *    rsize_t
- *    strnlen_s(const char *dest, rsize_t dmax)
- *
- * DESCRIPTION
+ * @brief
  *    The strnlen_s function computes the length of the string pointed
  *    to by dest.
  *
- * SPECIFIED IN
+ * @remark SPECIFIED IN
  *    ISO/IEC TR 24731-1, Programming languages, environments
  *    and system software interfaces, Extensions to the C Library,
  *    Part I: Bounds-checking interfaces
  *
- * INPUT PARAMETERS
- *    dest      pointer to string
+ * @param  dest  pointer to string
+ * @param  dmax  maximum length of string
  *
- *    dmax      restricted maximum length.
+ * @pre  dest shall not be a null pointer.
+ * @pre  dmax shall not equal zero.
+ * @pre  dmax shall not be greater than RSIZE_MAX_STR.
  *
- * OUTPUT PARAMETERS
- *    none
+ * @return   The function returns the string length, excluding  the terminating
+ *           null character.  If dest is NULL, then strnlen_s returns 0.
+ *           \n Otherwise, the strnlen_s function returns the number of characters
+ *           that precede the terminating null character. If there is no null
+ *           character in the first dmax characters of dest then strnlen_s returns
+ *           dmax. At most the first dmax characters of dest are accessed
+ *           by strnlen_s.
  *
- * RUNTIME CONSTRAINTS
- *    dest shall not be a null pointer
- *    dmax shall not be greater than RSIZE_MAX_STR
- *    dmax shall not equal zero
- *
- * RETURN VALUE
- *    The function returns the string length, excluding  the terminating
- *    null character.  If dest is NULL, then strnlen_s returns 0.
- *
- *    Otherwise, the strnlen_s function returns the number of characters
- *    that precede the terminating null character. If there is no null
- *    character in the first dmax characters of dest then strnlen_s returns
- *    dmax. At most the first dmax characters of dest are accessed
- *    by strnlen_s.
- *
- * ALSO SEE
+ * @see
  *    strnterminate_s()
  *
  */

--- a/src/safeclib/strnterminate_s.c
+++ b/src/safeclib/strnterminate_s.c
@@ -35,43 +35,29 @@
 
 
 /**
- * NAME
- *    strnterminate_s
- *
- * SYNOPSIS
- *    #include "safe_str_lib.h"
- *    rsize_t
- *    strnterminate_s(char *dest, rsize_t dmax)
- *
- * DESCRIPTION
+ * @brief
  *    The strnterminate_s function will terminate the string if a
  *    null is not encountered before dmax characters.
  *
- * EXTENSION TO
+ * @remark EXTENSION TO
  *    ISO/IEC TR 24731-1, Programming languages, environments
  *    and system software interfaces, Extensions to the C Library,
  *    Part I: Bounds-checking interfaces
  *
- * INPUT PARAMETERS
- *    dest - pointer to string
+ * @param  dest  pointer to string
+ * @param  dmax  maximum length of string
  *
- *    dmax - restricted maximum length
+ * @pre  dest shall not be a null pointer.
+ * @pre  dmax shall not equal zero.
+ * @pre  dmax shall not be greater than RSIZE_MAX_STR.
  *
- * OUTPUT PARAMETERS
- *    dest - dest is terminated if needed
- *
- * RUNTIME CONSTRAINTS
- *    dest shall not be a null pointer
- *    dmax shall not be greater than RSIZE_MAX_STR
- *    dmax shall not equal zero
- *
- * RETURN VALUE
+ * @return
  *    The function returns a terminated string.  If a null is not
  *    encountered prior to dmax characters, the dmax character is
  *    set to null terminating the string. The string length is
  *    also returned.
  *
- * ALSO SEE
+ * @see
  *    strnlen_s()
  *
  */

--- a/src/safeclib/strpbrk_s.c
+++ b/src/safeclib/strpbrk_s.c
@@ -35,54 +35,32 @@
 
 
 /**
- * NAME
- *    strpbrk_s
- *
- * SYNOPSIS
- *    #include "safe_str_lib.h"
- *    errno_t
- *    strpbrk_s(char *dest, rsize_t dmax,
- *              char *src,  rsize_t slen, char **first)
- *
- * DESCRIPTION
+ * @brief
  *    Returns a pointer, first, to the first ocurrence of any character
  *    in src which is contained in dest.
  *
- * EXTENSION TO
+ * @remark EXTENSION TO
  *    ISO/IEC TR 24731, Programming languages, environments
  *    and system software interfaces, Extensions to the C Library,
  *    Part I: Bounds-checking interfaces
  *
- * INPUT PARAMETERS
- *    dest     pointer to string
+ * @param  dest   pointer to string to compare against
+ * @param  dmax   restricted maximum length of string dest
+ * @param  src    pointer to the string
+ * @param  slen   restricted length of string src
+ * @param  first  returned pointer to first occurence
  *
- *    dmax     restricted maximum length of string dest
+ * @pre  Neither dest nor src shall be a null pointer.
+ * @pre  Neither dmax nor slen shall not be 0.
+ * @pre  Neither dmax nor slen shall not be greater than RSIZE_MAX_STR.
  *
- *    src      pointer to string
+ * @return  pointer to the first ocurrence of any character contained in src
+ * @retval  EOK         when successful operation
+ * @retval  ESNULLP     when dest/src/first is NULL pointer
+ * @retval  ESZEROL     when dmax/slen = 0
+ * @retval  ESLEMAX     when dmax/slen > RSIZE_MAX_STR
  *
- *    slen     restricted length of string src
- *
- *    first    returned pointer to first occurence
- *
- * OUTPUT PARAMETERS
- *    none
- *
- * RUNTIME CONSTRAINTS
- *    Neither dest nor src shall be a null pointer.
- *    first shall not be a null pointer.
- *    dmax shall not be 0
- *    dmax shall not be greater than RSIZE_MAX_STR
- *
- * RETURN VALUE
- *    pointer to the first ocurrence of any character
- *    contained in src
- *
- *    EOK         count
- *    ESNULLP     NULL pointer
- *    ESZEROL     zero length
- *    ESLEMAX     length exceeds max limit
- *
- * ALSO SEE
+ * @see
  *    strfirstchar_s(), strlastchar_s(), strfirstdiff_s(),
  *    strfirstsame_s(), strlastdiff_s(), strlastsame_s()
  *

--- a/src/safeclib/strprefix_s.c
+++ b/src/safeclib/strprefix_s.c
@@ -35,49 +35,34 @@
 
 
 /**
- * NAME
- *    strprefix_s
- *
- * SYNOPSIS
- *    #include "safe_str_lib.h"
- *    errno_t
- *    strprefix_s(const char *dest, rsize_t dmax, const char *src)
- *
- * DESCRIPTION
+ * @brief
  *    Determines if the prefix pointed to by src is at the
  *    beginning of string pointed to by dest.  The prefix
  *    must be a complete match in dest.  Useful for command
  *    or user input parsing.  The scanning stops at the first
  *    null in dest or src, or after dmax characters.
  *
- * EXTENSION TO
+ * @remark EXTENSION TO
  *    ISO/IEC TR 24731-1, Programming languages, environments
  *    and system software interfaces, Extensions to the C Library,
  *    Part I: Bounds-checking interfaces
  *
- * INPUT PARAMETERS
- *    dest       pointer to string to compare against
+ * @param  dest  pointer to string to compare against
+ * @param  dmax  restricted maximum length of dest
+ * @param  src   pointer to the prefix
  *
- *    dmax       restricted maximum length of dest
  *
- *    src        pointer to the prefix
+ * @pre  Neither dest nor src shall be a null pointer.
+ * @pre  Neither dmax nor slen shall not be 0.
+ * @pre  Neither dmax nor slen shall not be greater than RSIZE_MAX_STR.
  *
- * OUTPUT PARAMETERS
- *    none
+ * @retval  EOK        when successful operation, substring found.
+ * @retval  ESNULLP    when dest/src/substring is NULL pointer
+ * @retval  ESZEROL    when dmax/slen = 0
+ * @retval  ESLEMAX    when dmax/slen > RSIZE_MAX_STR
+ * @retval  ESNOTFND   when prefix not found in dest
  *
- * RUNTIME CONSTRAINTS
- *    Neither dest nor src shall be a null pointer.
- *    dmax shall not equal zero.
- *    dmax shall not be greater than RSIZE_MAX_STR.
- *
- * RETURN VALUE
- *    EOK        successful operation, prefix present in dest
- *    ESNULLP    NULL pointer
- *    ESZEROL    zero length
- *    ESLEMAX    length exceeds max limit
- *    ESNOTFND   prefix not found in dest
- *
- * ALSO SEE
+ * @see
  *    strspn_s(), strcspn_s(), strpbrk_s(), strstr_s()
  *
  */

--- a/src/safeclib/strremovews_s.c
+++ b/src/safeclib/strremovews_s.c
@@ -35,46 +35,34 @@
 
 
 /**
- * NAME
- *    strremovews_s
- *
- * SYNOPSIS
- *    #include "safe_str_lib.h"
- *    errno_t
- *    strremovews_s(char *dest, rsize_t dmax)
- *
- * DESCRIPTION
+ * @brief 
  *    Removes beginning and trailing whitespace from the string pointed to by
  *    dest by shifting the text left over writting the beginning whitespace.
+ * @details
  *    The shifted-trimmed text is null terminated.
- *
  *    The text is shifted so the original pointer can continue to be used. This
  *    is useful when the memory was malloc'ed and will need to be freed.
  *
- * EXTENSION TO
+ * @remark EXTENSION TO
  *    ISO/IEC TR 24731, Programming languages, environments
  *    and system software interfaces, Extensions to the C Library,
  *    Part I: Bounds-checking interfaces
  *
- * INPUT PARAMETERS
- *    dest    pointer to string to remove whitespace
+ * @param[out]  dest  pointer to string to left justify
+ * @param[in]   dmax  restricted maximum length of string
  *
- *    dmax    restricted maximum length of string
+ * @pre  dest shall not be a null pointer.
+ * @pre  dmax shall not be 0
+ * @pre  dmax shall not be greater than RSIZE_MAX_STR
+ * @pre  dest shall be null terminated
  *
- * RUNTIME CONSTRAINTS
- *    dest shall not be a null pointer.
- *    dmax shall not be 0
- *    dmax shall not be greater than RSIZE_MAX_STR
- *    dest shall be null terminated
+ * @retval  EOK         when successful operation
+ * @retval  ESNULLP     when dest is NULL pointer
+ * @retval  ESZEROL     when dmax = 0
+ * @retval  ESLEMAX     when dmax > RSIZE_MAX_STR
+ * @retval  ESUNTERM    when dest was not null terminated
  *
- * RETURN VALUE
- *    EOK
- *    ESNULLP     NULL pointer
- *    ESZEROL     zero length
- *    ESLEMAX     length exceeds max limit
- *    ESUNTERM    dest was not null terminated
- *
- * SEE ALSO
+ * @see
  *    strljustify_s(),
  *
  */

--- a/src/safeclib/strspn_s.c
+++ b/src/safeclib/strspn_s.c
@@ -35,53 +35,33 @@
 
 
 /**
- * NAME
- *    strspn_s
- *
- * SYNOPSIS
- *    #include "safe_str_lib.h"
- *    errno_t
- *    strspn_s(const char *dest, rsize_t dmax,
- *             const char *src,  rsize_t slen, rsize_t *count)
- *
- * DESCRIPTION
+ * @brief
  *    This function computes the prefix length of the string
  *    pointed to by dest which consists entirely of characters
  *    that are included from the string pointed to by src.
  *
- * EXTENSION TO
+ * @remark EXTENSION TO
  *    ISO/IEC TR 24731, Programming languages, environments
  *    and system software interfaces, Extensions to the C Library,
  *    Part I: Bounds-checking interfaces
  *
- * INPUT PARAMETERS
- *    dest     pointer to string to determine the prefix
+ * @param[in]   dest   pointer to string to determine the prefix
+ * @param[in]   dmax   restricted maximum length of string dest
+ * @param[in]   src    pointer to exclusion string
+ * @param[in]   slen   restricted maximum length of string src
+ * @param[out]  count  pointer to a count variable that will be updated with the dest substring length
+ *  
+ * @pre  Neither dest nor src shall be a null pointer.
+ * @pre  count shall not be a null pointer.
+ * @pre  Neither dmax nor slen shall not be 0.
+ * @pre  Neither dmax nor slen shall not be greater than RSIZE_MAX_STR.
  *
- *    dmax     restricted maximum length of string dest
+ * @retval  EOK        when successful operation, substring found.
+ * @retval  ESNULLP    when dest/src/substring is NULL pointer
+ * @retval  ESZEROL    when dmax/slen = 0
+ * @retval  ESLEMAX    when dmax/slen > RSIZE_MAX_STR
  *
- *    src      pointer to exclusion string
- *
- *    slen     restricted maximum length of string src
- *
- *    count    pointer to a count variable that will be updated
- *              with the dest substring length
- *
- * OUTPUT PARAMETERS
- *    count    updated count
- *
- * RUNTIME CONSTRAINTS
- *    Neither dest nor src shall be a null pointer.
- *    count shall not be a null pointer.
- *    dmax shall not be 0
- *    dmax shall not be greater than RSIZE_MAX_STR
- *
- * RETURN VALUE
- *    EOK         count
- *    ESNULLP     NULL pointer
- *    ESZEROL     zero length
- *    ESLEMAX     length exceeds max limit
- *
- * ALSO SEE
+ * @see
  *    strcspn_s(), strpbrk_s(), strstr_s(), strprefix_s()
  *
  */

--- a/src/safeclib/strstr_s.c
+++ b/src/safeclib/strstr_s.c
@@ -35,52 +35,33 @@
 
 
 /**
- * NAME
- *    strstr_s
- *
- * SYNOPSIS
- *    #include "safe_str_lib.h"
- *    errno_t
- *    strstr_s(char *dest, rsize_t dmax,
- *             const char *src, rsize_t slen, char **substring)
- *
- * DESCRIPTION
+ * @brief
  *    The strstr_s() function locates the first occurrence of the
  *    substring pointed to by src which would be located in the
  *    string pointed to by dest.
  *
- * EXTENSION TO
- *     ISO/IEC TR 24731, Programming languages, environments
- *     and system software interfaces, Extensions to the C Library,
- *     Part I: Bounds-checking interfaces
+ * @remark EXTENSION TO
+ *    ISO/IEC TR 24731, Programming languages, environments
+ *    and system software interfaces, Extensions to the C Library,
+ *    Part I: Bounds-checking interfaces
  *
- * INPUT PARAMETERS
- *     dest      pointer to string to be searched for the substring
+ * @param[in]   dest       pointer to string to be searched for the substring
+ * @param[in]   dmax       restricted maximum length of dest string
+ * @param[in]   src        pointer to the sub string
+ * @param[in]   slen       the maximum number of characters to copy from src
+ * @param[out]  substring  the returned substring pointer
  *
- *     dmax      restricted maximum length of dest string
+ * @pre  Neither dest nor src shall be a null pointer.
+ * @pre  Neither dmax nor slen shall not be 0.
+ * @pre  Neither dmax nor slen shall not be greater than RSIZE_MAX_STR.
  *
- *     src       pointer to the sub string
+ * @retval  EOK        when successful operation, substring found.
+ * @retval  ESNULLP    when dest/src/substring is NULL pointer
+ * @retval  ESZEROL    when dmax/slen = 0
+ * @retval  ESLEMAX    when dmax/slen > RSIZE_MAX_STR
+ * @retval  ESNOTFND   when substring not found
  *
- *     slen      the maximum number of characters to copy from src
- *
- *     substring the returned substring pointer
- *
- * OUTPUT PARAMETERS
- *     substring  returned substring pointer
- *
- * RUNTIME CONSTRAINTS
- *     Neither dest nor src shall be a null pointer.
- *     Meither dmax nor slen shall be zero.
- *     Neither dmax nor slen shall be greater than RSIZE_MAX_STR.
- *
- * RETURN VALUE
- *     EOK        successful operation, substring found.
- *     ESNULLP    NULL pointer
- *     ESZEROL    zero length
- *     ESLEMAX    length exceeds max limit
- *     ESNOTFND   substring not found
- *
- * ALSO SEE
+ * @see
  *     strprefix_s(), strspn_s(), strcspn_s(), strpbrk_s()
  *
  */

--- a/src/safeclib/strtolowercase_s.c
+++ b/src/safeclib/strtolowercase_s.c
@@ -35,50 +35,35 @@
 
 
 /**
- * NAME
- *    strtolowercase_s
- *
- * SYNOPSIS
- *    #include "safe_str_lib.h"
- *    errno_t
- *    strlolowercase_s(char * restrict dest, rsize_t dmax)
- *
- * DESCRIPTION
+ * @brief
  *    Scans the string converting uppercase characters to
  *    lowercase, leaving all other characters unchanged.
  *    The scanning stops at the first null or after dmax
  *    characters.
  *
- * Extenstion to:
+ * @remark EXTENSION TO
  *    ISO/IEC TR 24731, Programming languages, environments
  *    and system software interfaces, Extensions to the C Library,
  *    Part I: Bounds-checking interfaces
  *
- * INPUT PARAMETERS
- *    dest       pointer to string
+ * @param[out]  dest  pointer to string
+ * @param[in]   dmax  maximum length of string
  *
- *    dmax       maximum length of string
+ * @pre  dest shall not be a null pointer.
+ * @pre  dmax shall not equal zero.
+ * @pre  dmax shall not be greater than RSIZE_MAX_STR.
  *
- * OUTPUT PARAMETERS
- *    dest       updated string
+ * @retval  EOK         when successful operation
+ * @retval  ESNULLP     when dest is NULL pointer
+ * @retval  ESZEROL     when dmax = 0
+ * @retval  ESLEMAX     when dmax > RSIZE_MAX_STR
  *
- * RUNTIME CONSTRAINTS
- *    dest shall not be a null pointer.
- *    dmax shall not equal zero.
- *    dmax shall not be greater than RSIZE_MAX_STR.
- *
- * RETURN VALUE
- *    EOK        successful operation
- *    ESNULLP    NULL pointer
- *    ESZEROL    zero length
- *    ESLEMAX    length exceeds max limit
- *
- * ALSO SEE
+ * @see
  *    strtouppercase_s()
  *
  */
 errno_t
-strtolowercase_s(char * restrict dest, rsize_t dmax)
+strtolowercase_s (char * restrict dest, rsize_t dmax)
 {
     if (!dest) {
         invoke_safe_str_constraint_handler("strtolowercase_s: "

--- a/src/safeclib/strtouppercase_s.c
+++ b/src/safeclib/strtouppercase_s.c
@@ -35,43 +35,28 @@
 
 
 /**
- * NAME
- *    strtouppercase_s
- *
- * SYNOPSIS
- *    #include "safe_str_lib.h"
- *    errno_t
- *    strlouppercase_s(char *dest, rsize_t dmax)
- *
- * DESCRIPTION
+ * @brief
  *    Scans the string converting lowercase characters to
  *    uppercase, leaving all other characters unchanged.
  *    The scanning stops at the first null or after dmax
  *    characters.
  *
- * Extenstion to:
+ * @remark EXTENSION TO
  *    ISO/IEC TR 24731, Programming languages, environments
  *    and system software interfaces, Extensions to the C Library,
  *    Part I: Bounds-checking interfaces
  *
- * INPUT PARAMETERS
- *    dest       pointer to string
+ * @param[out]  dest  pointer to string
+ * @param[in]   dmax  maximum length of string
  *
- *    dmax       maximum length of string
+ * @pre  dest shall not be a null pointer.
+ * @pre  dmax shall not equal zero.
+ * @pre  dmax shall not be greater than RSIZE_MAX_STR.
  *
- * OUTPUT PARAMETERS
- *    dest       updated string
- *
- * RUNTIME CONSTRAINTS
- *    dest shall not be a null pointer.
- *    dmax shall not equal zero.
- *    dmax shall not be greater than RSIZE_MAX_STR.
- *
- * RETURN VALUE
- *    EOK        successful operation
- *    ESNULLP    NULL pointer
- *    ESZEROL    zero length
- *    ESLEMAX    length exceeds max limit
+ * @retval  EOK         when successful operation
+ * @retval  ESNULLP     when dest is NULL pointer
+ * @retval  ESZEROL     when dmax = 0
+ * @retval  ESLEMAX     when dmax > RSIZE_MAX_STR
  *
  * ALSO SEE
  *    strtolowercase_s()

--- a/src/safeclib/strzero_s.c
+++ b/src/safeclib/strzero_s.c
@@ -35,38 +35,24 @@
 
 
 /**
- * NAME
- *    strzero_s
- *
- * SYNOPSIS
- *    #include "safe_str_lib.h"
- *    errno_t
- *    strzero_s(char *dest, rsize_t dmax)
- *
- * DESCRIPTION
+ * @brief
  *    Nulls dmax characters of dest.  This function can be used
  *    to clear strings that contained sensitive data.
  *
- * EXTENSION TO
+ * @remark EXTENSION TO
  *    ISO/IEC TR 24731, Programming languages, environments
  *    and system software interfaces, Extensions to the C Library,
  *    Part I: Bounds-checking interfaces
  *
- * INPUT PARAMETERS
- *    dest     pointer to string that will be nulled.
+ * @param[out]  dest  pointer to string that will be nulled.
+ * @param[in]   dmax  restricted maximum length of dest
  *
- *    dmax     restricted maximum length of dest
+ * @retval  EOK         when successful operation
+ * @retval  ESNULLP     when dest is NULL pointer
+ * @retval  ESZEROL     when dmax = 0
+ * @retval  ESLEMAX     when dmax > RSIZE_MAX_STR
  *
- * OUTPUT PARAMETERS
- *    dest     updated string
- *
- * RETURN VALUE
- *    EOK        successful operation
- *    ESNULLP    NULL pointer
- *    ESZEROL    zero length
- *    ESLEMAX    length exceeds max limit
- *
- * ALSO SEE
+ * @see
  *    strispassword_s()
  *
  */


### PR DESCRIPTION
# Description:
<!-- This is where the designer gives a detailed description of the change and why it is needed. -->
In reference to [issue#3](https://github.com/rurban/safeclib/issues/3) & [issue#4](https://github.com/rurban/safeclib/issues/4)

We are ready to demonstrate our changes.
1) Added doxygen tags to SafeC lib header comments.
 The following tags were used: 
 @brief: Tells in brief the functionality of functionality.
 @details: Tells complete description of the functionality.
 @param: Tells about the parameters used by function. [in] denotes parameter is an input & [out] 
                 denotes parameter is an output.
 @remark: Tells additional details about the function (E.g. Specified in/Extension to specific technical 
                  report)
 @return: Tells about what function returns.
 @retval: Tells about the return values.
 @code & @endcode: Used to demonstrate sample code.
 @see: Tells about related functions.
 
 For more details you can look for [doxygen manual](https://www.stack.nl/~dimitri/doxygen/manual/commands.html).

2) We have synced parameter names used in functions in [mem_primitives_lib.c](https://github.com/rurban/safeclib/blob/master/src/safeclib/mem_primitives_lib.c) with 
 [mem_primitives_lib.h](https://github.com/rurban/safeclib/blob/master/src/safeclib/mem_primitives_lib.h). 
 Function signatures we synced:
  a. mem_prim_set(): Parameter uint32_t len modified to uint32_t dmax.
  b. mem_prim_set16()/mem_prim_set32() : Parameters uint16_t *dp & uint32_t len were modified to uint16_t *dest & uint32_t dmax respectively.
  c. mem_prim_move(): Parameter uint32_t len modified to uint32_t length.
  d. mem_prim_move8() /mem_prim_move16() /mem_prim_move32() : Parameters uint32_t *dp, const uint32_t *sp & uint32_t len were modified to uint32_t *dest, const uint32_t *src & uint32_t length respectively.
  
# Reviewers:
<!-- This is a list of @MENTION names of people the designer wishes to review the code. -->
@rurban 

# Observers:
<!-- This is a list of @MENTION names of the people the designer wishes to be notified of the code
change. This role is the same as it was in WIT inspections. It is a separate list from the Owners
and may be left blank. -->
@jeremyhannon - Jeremy Hannon - coworker/coauthor
