### PR TITLE
replace 'ssize_t' with 'size_t'.

### DIFF
--- a/src/wchar/mbsrtowcs_s.c
+++ b/src/wchar/mbsrtowcs_s.c
@@ -172,7 +172,7 @@ mbsrtowcs_s (size_t *restrict retval,
 
     *retval = mbsrtowcs(dest, src, len, ps);
 
-    if (likely((ssize_t)*retval > 0 && *retval < dmax)) {
+    if (likely(*retval > 0 && *retval < dmax)) {
         if (dest) {
 #ifdef SAFECLIB_STR_NULL_SLACK
             memset(&dest[*retval], 0, (dmax-*retval)*sizeof(wchar_t));
@@ -187,8 +187,9 @@ mbsrtowcs_s (size_t *restrict retval,
             size_t tmp = 0;
             errno = 0;
             /* with NULL either 0 or -1 is returned */
-            if ((ssize_t)*retval < 0) /* else ESNOSPC */
-                tmp = mbsrtowcs(NULL, src, len-1, &orig_ps);
+            if (*retval > RSIZE_MAX_STR) { /* else ESNOSPC */
+                tmp = mbsrtowcs(NULL, src, len - 1, &orig_ps);
+            }
             rc = (tmp == 0) ? ESNOSPC : errno;
             /* the entire src must have been copied, if not reset dest
              * to null the string. (only with SAFECLIB_STR_NULL_SLACK) */
@@ -197,8 +198,9 @@ mbsrtowcs_s (size_t *restrict retval,
                               : "mbsrtowcs_s: illegal sequence",
                          rc);
         }
-        else
+        else {
             rc = ((size_t)*retval == 0) ? EOK : errno;
+        }
         return RCNEGATE(rc);
     }
 

--- a/src/wchar/mbstowcs_s.c
+++ b/src/wchar/mbstowcs_s.c
@@ -161,7 +161,7 @@ mbstowcs_s(size_t *restrict retval,
 
     *retval = mbstowcs(dest, src, len);
 
-    if (likely((ssize_t)*retval > 0 && *retval < dmax)) {
+    if (likely(*retval > 0 && *retval < dmax)) {
         if (dest) {
 #ifdef SAFECLIB_STR_NULL_SLACK
             memset(&dest[*retval], 0, (dmax-*retval)*sizeof(wchar_t));
@@ -175,8 +175,9 @@ mbstowcs_s(size_t *restrict retval,
         if (dest) {
             size_t tmp = 0;
             errno = 0;
-            if ((ssize_t)*retval < 0) /* else ESNOSPC */
+            if (*retval > RSIZE_MAX_STR) { /* else ESNOSPC */
                 tmp = mbstowcs(NULL, src, len);
+            }
             /* with NULL either 0 or -1 is returned */
             rc = (tmp == 0) ? ESNOSPC : errno;
             /* the entire src must have been copied, if not reset dest
@@ -186,8 +187,9 @@ mbstowcs_s(size_t *restrict retval,
                               : "mbstowcs_s: illegal sequence",
                          rc);
         }
-        else
+        else {
             rc = ((size_t)*retval == 0) ? EOK : errno;
+        }
         return RCNEGATE(rc);
     }
 

--- a/src/wchar/wcrtomb_s.c
+++ b/src/wchar/wcrtomb_s.c
@@ -145,17 +145,18 @@ wcrtomb_s(size_t *restrict retval,
 
     len = *retval = wcrtomb(dest, wc, ps);
 
-    if (likely((ssize_t)len > 0 && (rsize_t)len < dmax)) {
-        if (dest)
+    if (likely(len > 0 && (rsize_t)len < dmax)) {
+        if (dest) {
 #ifdef SAFECLIB_STR_NULL_SLACK
-            memset(&dest[len], 0, dmax-len);
+            memset(&dest[len], 0, dmax - len);
 #else
             dest[len] = '\0';
 #endif
+        }
         return EOK;
     } else {
         /* errno is usually EILSEQ */
-        errno_t rc = ((ssize_t)len > 0) ? ESNOSPC : errno;
+        errno_t rc = (len > 0 && len <= RSIZE_MAX_STR) ? ESNOSPC : errno;
         if (dest) {
             /* the entire src must have been copied, if not reset dest
              * to null the string. (only with SAFECLIB_STR_NULL_SLACK)

--- a/src/wchar/wcsrtombs_s.c
+++ b/src/wchar/wcsrtombs_s.c
@@ -153,30 +153,31 @@ wcsrtombs_s (size_t *restrict retval,
     }
 
     if (unlikely(src == NULL)) {
-        if (dest)
-            handle_error(dest, dmax, "wcsrtombs_s: src is null",
-                         ESNULLP);
+        if (dest) {
+            handle_error(dest, dmax, "wcsrtombs_s: src is null", ESNULLP);
+        }
         return RCNEGATE(ESNULLP);
     }
 
     if (unlikely(*src == NULL)) {
-        if (dest)
-            handle_error(dest, dmax, "wcsrtombs_s: *src is null",
-                         ESNULLP);
+        if (dest) {
+            handle_error(dest, dmax, "wcsrtombs_s: *src is null", ESNULLP);
+        }
         return RCNEGATE(ESNULLP);
     }
 
     l = *retval = wcsrtombs(dest, src, len, ps);
 
-    if (likely((ssize_t)l > 0 && l < dmax)) {
+    if (likely(l > 0 && l < dmax)) {
 #ifdef SAFECLIB_STR_NULL_SLACK
-        if (dest)
+        if (dest) {
             memset(&dest[l], 0, dmax-l);
+        }
 #endif
         return EOK;
     } else {
         /* errno is usually EILSEQ */
-        errno_t rc = ((ssize_t)l > 0) ? ESNOSPC : errno;
+        errno_t rc = (l > 0 && l <= RSIZE_MAX_STR) ? ESNOSPC : errno;
         if (dest) {
             /* the entire src must have been copied, if not reset dest
              * to null the string. (only with SAFECLIB_STR_NULL_SLACK)

--- a/src/wchar/wcstombs_s.c
+++ b/src/wchar/wcstombs_s.c
@@ -149,19 +149,19 @@ wcstombs_s (size_t *restrict retval,
     }
 
     if (unlikely(src == NULL)) {
-        if (dest)
-            handle_error(dest, dmax, "wcstombs_s: src is null",
-                         ESNULLP);
+        if (dest) {
+            handle_error(dest, dmax, "wcstombs_s: src is null", ESNULLP);
+        }
         return RCNEGATE(ESNULLP);
     }
 
     /* l is the strlen, excluding NULL */
     l = *retval = wcstombs(dest, src, len);
 
-    if (likely((ssize_t)l > 0 && (rsize_t)l < dmax)) {
+    if (likely(l > 0 && (rsize_t)l < dmax)) {
         if (dest) {
 #ifdef SAFECLIB_STR_NULL_SLACK
-            memset(&dest[l], 0, dmax-l);
+            memset(&dest[l], 0, dmax - l);
 #else
             /* wcstombs only ensures null-termination when len is big enough.
              * Above we ensured l < dmax, otherwise ESNOSPC. */
@@ -171,7 +171,7 @@ wcstombs_s (size_t *restrict retval,
         return EOK;
     } else {
         /* errno is usually EILSEQ */
-        errno_t rc = ((ssize_t)l > 0) ? ESNOSPC : errno;
+        errno_t rc = (l > 0 && l <= RSIZE_MAX_STR) ? ESNOSPC : errno;
         if (dest) {
             /* the entire src must have been copied, if not reset dest
              * to null the string with SAFECLIB_STR_NULL_SLACK. */

--- a/tests/test_wcsnorm_s.c
+++ b/tests/test_wcsnorm_s.c
@@ -38,7 +38,7 @@ int main()
     wchar_t str[LEN];
     wchar_t str1[LEN];
     rsize_t ind;
-    ssize_t len;
+    size_t len;
     int errs = 0;
 #ifdef PERL_TEST
     FILE *pl;


### PR DESCRIPTION
We're setting up building `safeclib` with the IAR compiler for the RX family of processors. Evidently the type `ssize_t` is GCC-specific and not supported. One solution would be to define the `ssize_t` type if it's not present, but the better solution seemed to be to replace all uses of `ssize_t` with `size_t`.

* The C99 wide character functions involved all return type `size_t` anyways. So no need to reinterpret the `size_t` return values as `ssize_t`.
* `ssize_t` will ALWAYS be signed whereas `size_t` can be either signed or unsigned. Therefore the comparison logic had to change to avoid comparisons less than zero. Therefore instead check for values greater than `RSIZE_MAX_STR` to catch `-1` rollover error codes.

I also added curly brackets around all if-else contexts. All looping and control structures should use both a beginning and ending curly bracket.
  