### PR TITLE
Update run-time constraint violation checks

### DIFF
--- a/src/str/strncat_s.c
+++ b/src/str/strncat_s.c
@@ -102,18 +102,6 @@ strncat_s (char * restrict dest, rsize_t dmax, const char * restrict src, rsize_
         return RCNEGATE(ESNULLP);
     }
 
-    if (unlikely(src == NULL)) {
-        invoke_safe_str_constraint_handler("strncat_s: src is null",
-                   NULL, ESNULLP);
-        return RCNEGATE(ESNULLP);
-    }
-
-    if (unlikely(slen > RSIZE_MAX_STR)) {
-        invoke_safe_str_constraint_handler("strncat_s: slen exceeds max",
-                   NULL, ESLEMAX);
-        return RCNEGATE(ESLEMAX);
-    }
-
     if (unlikely(dmax == 0)) {
         invoke_safe_str_constraint_handler("strncat_s: dmax is 0",
                    NULL, ESZEROL);
@@ -123,6 +111,20 @@ strncat_s (char * restrict dest, rsize_t dmax, const char * restrict src, rsize_
     if (unlikely(dmax > RSIZE_MAX_STR)) {
         invoke_safe_str_constraint_handler("strncat_s: dmax exceeds max",
                    NULL, ESLEMAX);
+        return RCNEGATE(ESLEMAX);
+    }
+
+    if (unlikely(src == NULL)) {
+        invoke_safe_str_constraint_handler("strncat_s: src is null",
+                   NULL, ESNULLP);
+        *dest = '\0';
+        return RCNEGATE(ESNULLP);
+    }
+
+    if (unlikely(slen > RSIZE_MAX_STR)) {
+        invoke_safe_str_constraint_handler("strncat_s: slen exceeds max",
+                   NULL, ESLEMAX);
+        *dest = '\0';
         return RCNEGATE(ESLEMAX);
     }
 

--- a/src/str/strncpy_s.c
+++ b/src/str/strncpy_s.c
@@ -119,6 +119,7 @@ strncpy_s (char * restrict dest, rsize_t dmax, const char * restrict src, rsize_
         handle_error(orig_dest, orig_dmax, "strncpy_s: "
                      "src is null",
                      ESNULLP);
+        *dest = '\0';
         return RCNEGATE(ESNULLP);
     }
 
@@ -138,6 +139,7 @@ strncpy_s (char * restrict dest, rsize_t dmax, const char * restrict src, rsize_
         handle_error(orig_dest, orig_dmax, "strncpy_s: "
                      "slen exceeds max",
                      ESLEMAX);
+        *dest = '\0';
         return RCNEGATE(ESLEMAX);
     }
 
@@ -153,7 +155,7 @@ strncpy_s (char * restrict dest, rsize_t dmax, const char * restrict src, rsize_
                 return RCNEGATE(ESOVRLP);
             }
 
-            if (unlikely(slen == 0)) {
+	    if (unlikely(slen == 0)) {
                 /*
                  * Copying truncated to slen chars.  Note that the TR says to
                  * copy slen chars plus the null char.  We null the slack.

--- a/src/wchar/wcsncat_s.c
+++ b/src/wchar/wcsncat_s.c
@@ -106,18 +106,6 @@ wcsncat_s(wchar_t *restrict dest, rsize_t dmax,
         return RCNEGATE(ESNULLP);
     }
 
-    if (unlikely(src == NULL)) {
-        invoke_safe_str_constraint_handler("wcsncat_s: src is null",
-                   NULL, ESNULLP);
-        return RCNEGATE(ESNULLP);
-    }
-
-    if (unlikely(slen > RSIZE_MAX_STR)) {
-        invoke_safe_str_constraint_handler("wcsncat_s: slen exceeds max",
-                   NULL, ESLEMAX);
-        return RCNEGATE(ESLEMAX);
-    }
-
     if (unlikely(dmax == 0)) {
         invoke_safe_str_constraint_handler("wcsncat_s: dmax is 0",
                    NULL, ESZEROL);
@@ -127,6 +115,25 @@ wcsncat_s(wchar_t *restrict dest, rsize_t dmax,
     if (unlikely(dmax > RSIZE_MAX_STR)) {
         invoke_safe_str_constraint_handler("wcsncat_s: dmax exceeds max",
                    NULL, ESLEMAX);
+        return RCNEGATE(ESLEMAX);
+    }
+
+    if (unlikely(src == NULL)) {
+#ifdef SAFECLIB_STR_NULL_SLACK
+        /* null string to clear data */
+        while (dmax) {  *dest = L'\0'; dmax--; dest++; }
+#else
+        *dest = L'\0';
+#endif
+        invoke_safe_str_constraint_handler("wcsncat_s: src is null",
+                   NULL, ESNULLP);
+        return RCNEGATE(ESNULLP);
+    }
+
+    if (unlikely(slen > RSIZE_MAX_STR)) {
+        invoke_safe_str_constraint_handler("wcsncat_s: slen exceeds max",
+                   NULL, ESLEMAX);
+        *dest = L'\0';
         return RCNEGATE(ESLEMAX);
     }
 

--- a/src/wchar/wcsncpy_s.c
+++ b/src/wchar/wcsncpy_s.c
@@ -141,6 +141,7 @@ wcsncpy_s (wchar_t * restrict dest, rsize_t dmax, const wchar_t * restrict src, 
         handle_werror(orig_dest, orig_dmax, "wcsncpy_s: "
                      "slen exceeds max",
                      ESLEMAX);
+        *dest = L'\0';
         return RCNEGATE(ESLEMAX);
     }
 
@@ -194,7 +195,7 @@ wcsncpy_s (wchar_t * restrict dest, rsize_t dmax, const wchar_t * restrict src, 
                 return RCNEGATE(ESOVRLP);
             }
 
-            if (unlikely(slen == 0)) {
+	    if (unlikely(slen == 0)) {
                 /*
                  * Copying truncated to slen chars.  Note that the TR says to
                  * copy slen chars plus the null char.  We null the slack.


### PR DESCRIPTION
# Reviewer
@rurban 

# Observer
@jeremyhannon 

# Description
It was observed that for strncpy_s, strncat_s, wcsncpy_s & wcsncat_s,
some of the run-time constraint violation weren't performing the corrective action.
1) src = NULL when dst != NULL & dmax !=0 && less than RSIZE_MAX_STR is a run-time
violation & we need to update dst[0] = 0; in this scenario which was missing.

2) slen > RSIZE_MAX_STR is also a runtime constraint violation  &
we need to update dst[0] = 0; in this scenario which was missing.

# Note
Order of the checks is being reshuffled to catch run-time constraint violation.