### PR TITLE
Fix kernel module

### DIFF
--- a/Kbuild
+++ b/Kbuild
@@ -31,6 +31,10 @@
 obj-m     := slkm.o testslkm.o
 
 ccflags-y := -I$(src)/include
+ccflags-y += -I$(src)
+ccflags-y += -I$(src)/src
+ccflags-y += -I$(src)/src/str
+ccflags-y += -I$(src)/src/mem
 
 # Functions in the kernel that don't have a 1-to-1 name correlation
 # __HAVE_ARCH_STRLCPY
@@ -68,7 +72,7 @@ slkm-y     += src/str/strcpy_s.o
 slkm-y     += src/str/strncpy_s.o
 slkm-y     += src/str/strcat_s.o
 slkm-y     += src/str/strncat_s.o
-slkm-y     += src/str/strcmp_s.o
+slkm-y     += src/extstr/strcmp_s.o
 slkm-y     += src/str/strnlen_s.o
 slkm-y     += src/extstr/strcasecmp_s.o
 slkm-y     += src/extstr/strstr_s.o

--- a/README
+++ b/README
@@ -185,7 +185,7 @@ build the kernel module.
 
 .To build do the following:
 
-    $ ./configure
+    $ ./configure --disable-wchar
     $ make -f Makefile.kernel
 
 

--- a/include/safe_lib.h
+++ b/include/safe_lib.h
@@ -57,10 +57,12 @@ extern "C" {
 # define EXTERN extern
 #endif
 
+#ifndef __KERNEL__
 #include <time.h>
 #if defined HAVE_SYS_TIME_H
 #include <sys/time.h>
 #endif
+#endif /* __KERNEL__ */
 
 #if defined __MINGW64_VERSION_MAJOR
 #  define HAVE_MINGW64  /* mingw-w64 (either 32 or 64bit) */
@@ -109,14 +111,17 @@ EXTERN errno_t
 tmpnam_s(char *filename_s, rsize_t maxsize);
 #endif
 
+#ifndef __KERNEL__
 EXTERN errno_t
 tmpfile_s(FILE * restrict * restrict streamptr);
+#endif /* __KERNEL__ */
 
 EXTERN char *
 gets_s(char *dest, rsize_t dmax);
 
 /* Windows sec_api does without restrict */
 #ifndef MINGW_HAS_SECURE_API
+#ifndef __KERNEL__
 EXTERN errno_t
 fopen_s(FILE *restrict *restrict streamptr,
         const char *restrict filename,
@@ -126,6 +131,7 @@ EXTERN errno_t
 freopen_s(FILE *restrict *restrict newstreamptr,
           const char *restrict filename, const char *restrict mode,
           FILE *restrict stream);
+#endif /* __KERNEL__ */
 
 EXTERN errno_t
 asctime_s(char *dest, rsize_t dmax, const struct tm *tm);

--- a/include/safe_str_lib.h
+++ b/include/safe_str_lib.h
@@ -43,10 +43,12 @@ extern "C" {
 #include "safe_types.h"
 
 #include <stdarg.h>
+#ifndef __KERNEL__
 #include <time.h>
 #if defined HAVE_SYS_TIME_H
 #include <sys/time.h>
 #endif
+#endif /* __KERNEL__ */
 #ifndef SAFECLIB_DISABLE_WCHAR
 #include <wchar.h>
 #endif
@@ -160,8 +162,10 @@ vsnprintf_s(char *restrict dest, rsize_t dmax, const char *restrict fmt, va_list
 EXTERN int
 sscanf_s(const char *restrict buffer, const char *restrict fmt, ...);
 
+#ifndef __KERNEL__
 EXTERN int
 fscanf_s(FILE *restrict stream, const char *restrict format, ...);
+#endif /* __KERNEL__ */
 
 EXTERN int
 scanf_s(const char *restrict format, ...);
@@ -169,9 +173,11 @@ scanf_s(const char *restrict format, ...);
 EXTERN int
 vscanf_s(const char *restrict format, va_list vlist);
 
+#ifndef __KERNEL__
 EXTERN int
 vfscanf_s(FILE *restrict stream, const char *restrict format,
           va_list vlist);
+#endif /* __KERNEL__ */
 
 EXTERN int
 vsscanf_s(const char *restrict buffer, const char *restrict format,
@@ -180,15 +186,19 @@ vsscanf_s(const char *restrict buffer, const char *restrict format,
 EXTERN int
 printf_s(const char *restrict format, ...);
 
+#ifndef __KERNEL__
 EXTERN int
 fprintf_s(FILE *restrict stream, const char *restrict format, ...);
+#endif /* __KERNEL__ */
 
 EXTERN int
 vprintf_s(const char *restrict format, va_list arg);
 
+#ifndef __KERNEL__
 EXTERN int
 vfprintf_s(FILE *restrict stream, const char *restrict format,
            va_list arg);
+#endif /* __KERNEL__ */
 
 EXTERN errno_t
 strerror_s(char *dest, rsize_t dmax, errno_t errnum);
@@ -490,12 +500,14 @@ wprintf_s( const wchar_t *restrict fmt, ...);
 EXTERN int
 vwprintf_s(const wchar_t *restrict fmt, va_list ap);
 
+#ifndef __KERNEL__
 EXTERN int
 fwprintf_s(FILE *restrict stream, const wchar_t *restrict fmt, ...);
 
 EXTERN int
 vfwprintf_s(FILE * restrict stream,
             const wchar_t *restrict fmt, va_list ap);
+#endif /* __KERNEL__ */
 
 EXTERN int
 swscanf_s(const wchar_t *restrict buffer,
@@ -511,6 +523,7 @@ wscanf_s( const wchar_t *restrict fmt, ...);
 EXTERN int
 vwscanf_s(const wchar_t *restrict fmt, va_list ap);
 
+#ifndef __KERNEL__
 EXTERN int
 fwscanf_s(FILE *restrict stream,
           const wchar_t *restrict fmt, ...);
@@ -518,6 +531,7 @@ fwscanf_s(FILE *restrict stream,
 EXTERN int
 vfwscanf_s(FILE *restrict stream,
            const wchar_t *restrict fmt, va_list ap);
+#endif /* __KERNEL__ */
 
 
 #ifndef SAFECLIB_DISABLE_EXTENSIONS

--- a/src/abort_handler_s.c
+++ b/src/abort_handler_s.c
@@ -63,4 +63,6 @@ abort_handler_s(const char * restrict msg, void * restrict ptr, errno_t error)
 		 (msg) ? msg : "Null message");
 	slabort();
 }
-EXPORT_SYMBOL(abort_handler_s)
+#ifdef __KERNEL__
+EXPORT_SYMBOL(abort_handler_s);
+#endif /* __KERNEL__ */

--- a/src/extmem/memccpy_s.c
+++ b/src/extmem/memccpy_s.c
@@ -161,4 +161,6 @@ memccpy_s (void *restrict dest, rsize_t dmax, const void *restrict src,
                  ESNOSPC);
     return RCNEGATE(ESNOSPC);
 }
-EXPORT_SYMBOL(memccpy_s)
+#ifdef __KERNEL__
+EXPORT_SYMBOL(memccpy_s);
+#endif /* __KERNEL__ */

--- a/src/extmem/memcmp16_s.c
+++ b/src/extmem/memcmp16_s.c
@@ -155,4 +155,6 @@ memcmp16_s (const uint16_t *dest, rsize_t dmax,
 
     return (RCNEGATE(EOK));
 }
-EXPORT_SYMBOL(memcmp16_s)
+#ifdef __KERNEL__
+EXPORT_SYMBOL(memcmp16_s);
+#endif /* __KERNEL__ */

--- a/src/extmem/memcmp32_s.c
+++ b/src/extmem/memcmp32_s.c
@@ -147,4 +147,6 @@ memcmp32_s (const uint32_t *dest, rsize_t dmax,
 
     return (RCNEGATE(EOK));
 }
-EXPORT_SYMBOL(memcmp32_s)
+#ifdef __KERNEL__
+EXPORT_SYMBOL(memcmp32_s);
+#endif /* __KERNEL__ */

--- a/src/extmem/memcmp_s.c
+++ b/src/extmem/memcmp_s.c
@@ -157,4 +157,6 @@ memcmp_s (const void *dest, rsize_t dmax,
 
     return (RCNEGATE(EOK));
 }
-EXPORT_SYMBOL(memcmp_s)
+#ifdef __KERNEL__
+EXPORT_SYMBOL(memcmp_s);
+#endif /* __KERNEL__ */

--- a/src/extmem/memcpy16_s.c
+++ b/src/extmem/memcpy16_s.c
@@ -137,4 +137,6 @@ memcpy16_s (uint16_t *dest, rsize_t dmax, const uint16_t *src, rsize_t count)
 
     return (RCNEGATE(EOK));
 }
-EXPORT_SYMBOL(memcpy16_s)
+#ifdef __KERNEL__
+EXPORT_SYMBOL(memcpy16_s);
+#endif /* __KERNEL__ */

--- a/src/extmem/memcpy32_s.c
+++ b/src/extmem/memcpy32_s.c
@@ -133,4 +133,6 @@ memcpy32_s (uint32_t *dest, rsize_t dmax, const uint32_t *src, rsize_t count)
 
     return (RCNEGATE(EOK));
 }
-EXPORT_SYMBOL(memcpy32_s)
+#ifdef __KERNEL__
+EXPORT_SYMBOL(memcpy32_s);
+#endif /* __KERNEL__ */

--- a/src/extmem/memmove16_s.c
+++ b/src/extmem/memmove16_s.c
@@ -124,4 +124,6 @@ memmove16_s (uint16_t *dest, rsize_t dmax, const uint16_t *src, rsize_t count)
 
     return (RCNEGATE(EOK));
 }
-EXPORT_SYMBOL(memmove16_s)
+#ifdef __KERNEL__
+EXPORT_SYMBOL(memmove16_s);
+#endif /* __KERNEL__ */

--- a/src/extmem/memmove32_s.c
+++ b/src/extmem/memmove32_s.c
@@ -124,4 +124,6 @@ memmove32_s (uint32_t *dest, rsize_t dmax, const uint32_t *src, rsize_t count)
 
     return (RCNEGATE(EOK));
 }
-EXPORT_SYMBOL(memmove32_s)
+#ifdef __KERNEL__
+EXPORT_SYMBOL(memmove32_s);
+#endif /* __KERNEL__ */

--- a/src/extmem/memset16_s.c
+++ b/src/extmem/memset16_s.c
@@ -113,4 +113,6 @@ memset16_s(uint16_t *dest, rsize_t dmax, uint16_t value, rsize_t n)
 
     return (RCNEGATE(err));
 }
-EXPORT_SYMBOL(memset16_s)
+#ifdef __KERNEL__
+EXPORT_SYMBOL(memset16_s);
+#endif /* __KERNEL__ */

--- a/src/extmem/memset32_s.c
+++ b/src/extmem/memset32_s.c
@@ -112,4 +112,6 @@ memset32_s(uint32_t *dest, rsize_t dmax, uint32_t value, rsize_t n)
 
     return (RCNEGATE(err));
 }
-EXPORT_SYMBOL(memset32_s)
+#ifdef __KERNEL__
+EXPORT_SYMBOL(memset32_s);
+#endif /* __KERNEL__ */

--- a/src/extmem/memzero16_s.c
+++ b/src/extmem/memzero16_s.c
@@ -90,4 +90,6 @@ memzero16_s (uint16_t *dest, rsize_t len)
 
     return (RCNEGATE(EOK));
 }
-EXPORT_SYMBOL(memzero16_s)
+#ifdef __KERNEL__
+EXPORT_SYMBOL(memzero16_s);
+#endif /* __KERNEL__ */

--- a/src/extmem/memzero32_s.c
+++ b/src/extmem/memzero32_s.c
@@ -91,4 +91,6 @@ memzero32_s (uint32_t *dest, rsize_t len)
 
     return (RCNEGATE(EOK));
 }
-EXPORT_SYMBOL(memzero32_s)
+#ifdef __KERNEL__
+EXPORT_SYMBOL(memzero32_s);
+#endif /* __KERNEL__ */

--- a/src/extmem/memzero_s.c
+++ b/src/extmem/memzero_s.c
@@ -90,4 +90,6 @@ memzero_s (void *dest, rsize_t len)
 
     return (RCNEGATE(EOK));
 }
-EXPORT_SYMBOL(memzero_s)
+#ifdef __KERNEL__
+EXPORT_SYMBOL(memzero_s);
+#endif /* __KERNEL__ */

--- a/src/extmem/timingsafe_bcmp.c
+++ b/src/extmem/timingsafe_bcmp.c
@@ -58,4 +58,6 @@ timingsafe_bcmp (const void *b1, const void *b2, size_t n)
         ret |= *p1++ ^ *p2++;
     return (ret != 0);
 }
-EXPORT_SYMBOL(timingsafe_bcmp)
+#ifdef __KERNEL__
+EXPORT_SYMBOL(timingsafe_bcmp);
+#endif /* __KERNEL__ */

--- a/src/extmem/timingsafe_memcmp.c
+++ b/src/extmem/timingsafe_memcmp.c
@@ -75,4 +75,6 @@ timingsafe_memcmp (const void *b1, const void *b2, size_t len)
 
     return (res);
 }
-EXPORT_SYMBOL(timingsafe_memcmp)
+#ifdef __KERNEL__
+EXPORT_SYMBOL(timingsafe_memcmp);
+#endif /* __KERNEL__ */

--- a/src/extstr/strcasecmp_s.c
+++ b/src/extstr/strcasecmp_s.c
@@ -123,4 +123,6 @@ strcasecmp_s (const char *dest, rsize_t dmax,
     *indicator = (toupper(*udest) - toupper(*usrc));
     return RCNEGATE(EOK);
 }
-EXPORT_SYMBOL(strcasecmp_s)
+#ifdef __KERNEL__
+EXPORT_SYMBOL(strcasecmp_s);
+#endif /* __KERNEL__ */

--- a/src/extstr/strcmp_s.c
+++ b/src/extstr/strcmp_s.c
@@ -119,4 +119,6 @@ strcmp_s (const char *dest, rsize_t dmax,
     *indicator = *dest - *src;
     return RCNEGATE(EOK);
 }
-EXPORT_SYMBOL(strcmp_s)
+#ifdef __KERNEL__
+EXPORT_SYMBOL(strcmp_s);
+#endif /* __KERNEL__ */

--- a/src/extstr/strcoll_s.c
+++ b/src/extstr/strcoll_s.c
@@ -120,4 +120,6 @@ strcoll_s (const char *restrict dest, rsize_t dmax,
 
     return RCNEGATE(EOK);
 }
-EXPORT_SYMBOL(strcoll_s)
+#ifdef __KERNEL__
+EXPORT_SYMBOL(strcoll_s);
+#endif /* __KERNEL__ */

--- a/src/extstr/strcspn_s.c
+++ b/src/extstr/strcspn_s.c
@@ -144,4 +144,6 @@ strcspn_s (const char *dest, rsize_t dmax,
 
     return RCNEGATE(EOK);
 }
-EXPORT_SYMBOL(strcspn_s)
+#ifdef __KERNEL__
+EXPORT_SYMBOL(strcspn_s);
+#endif /* __KERNEL__ */

--- a/src/extstr/strpbrk_s.c
+++ b/src/extstr/strpbrk_s.c
@@ -139,4 +139,6 @@ strpbrk_s (char *dest, rsize_t dmax,
 
     return RCNEGATE(ESNOTFND);
 }
-EXPORT_SYMBOL(strpbrk_s)
+#ifdef __KERNEL__
+EXPORT_SYMBOL(strpbrk_s);
+#endif /* __KERNEL__ */

--- a/src/extstr/strspn_s.c
+++ b/src/extstr/strspn_s.c
@@ -149,4 +149,6 @@ strspn_s (const char *dest, rsize_t dmax,
 
     return RCNEGATE(EOK);
 }
-EXPORT_SYMBOL(strspn_s)
+#ifdef __KERNEL__
+EXPORT_SYMBOL(strspn_s);
+#endif /* __KERNEL__ */

--- a/src/extstr/strstr_s.c
+++ b/src/extstr/strstr_s.c
@@ -158,4 +158,6 @@ strstr_s (char *dest, rsize_t dmax,
     *substring = NULL;
     return RCNEGATE(ESNOTFND);
 }
-EXPORT_SYMBOL(strstr_s)
+#ifdef __KERNEL__
+EXPORT_SYMBOL(strstr_s);
+#endif /* __KERNEL__ */

--- a/src/extwchar/wcscmp_s.c
+++ b/src/extwchar/wcscmp_s.c
@@ -117,4 +117,6 @@ wcscmp_s(const wchar_t *restrict dest, rsize_t dmax,
     *diff = *dest - *src;
     return RCNEGATE(EOK);
 }
-EXPORT_SYMBOL(wcscmp_s)
+#ifdef __KERNEL__
+EXPORT_SYMBOL(wcscmp_s);
+#endif /* __KERNEL__ */

--- a/src/extwchar/wcscoll_s.c
+++ b/src/extwchar/wcscoll_s.c
@@ -122,4 +122,6 @@ wcscoll_s (const wchar_t *restrict dest, rsize_t dmax,
 
     return RCNEGATE(EOK);
 }
-EXPORT_SYMBOL(wcscoll_s)
+#ifdef __KERNEL__
+EXPORT_SYMBOL(wcscoll_s);
+#endif /* __KERNEL__ */

--- a/src/extwchar/wcsicmp_s.c
+++ b/src/extwchar/wcsicmp_s.c
@@ -123,4 +123,6 @@ wcsicmp_s(const wchar_t *restrict dest, rsize_t dmax,
     free(d2);
     return rc;
 }
-EXPORT_SYMBOL(wcsicmp_s)
+#ifdef __KERNEL__
+EXPORT_SYMBOL(wcsicmp_s);
+#endif /* __KERNEL__ */

--- a/src/extwchar/wcsncmp_s.c
+++ b/src/extwchar/wcsncmp_s.c
@@ -123,4 +123,6 @@ wcsncmp_s(const wchar_t *restrict dest, rsize_t dmax,
     *diff = *dest - *src;
     return RCNEGATE(EOK);
 }
-EXPORT_SYMBOL(wcsncmp_s)
+#ifdef __KERNEL__
+EXPORT_SYMBOL(wcsncmp_s);
+#endif /* __KERNEL__ */

--- a/src/extwchar/wcsstr.c
+++ b/src/extwchar/wcsstr.c
@@ -99,4 +99,6 @@ wcsstr (wchar_t *restrict dest, const wchar_t *restrict src)
     }
     return NULL;
 }
-EXPORT_SYMBOL(wcsstr)
+#ifdef __KERNEL__
+EXPORT_SYMBOL(wcsstr);
+#endif /* __KERNEL__ */

--- a/src/extwchar/wcsstr_s.c
+++ b/src/extwchar/wcsstr_s.c
@@ -159,4 +159,6 @@ wcsstr_s (wchar_t *restrict dest, rsize_t dmax,
     *substring = NULL;
     return RCNEGATE(ESNOTFND);
 }
-EXPORT_SYMBOL(wcsstr_s)
+#ifdef __KERNEL__
+EXPORT_SYMBOL(wcsstr_s);
+#endif /* __KERNEL__ */

--- a/src/extwchar/wmemcmp_s.c
+++ b/src/extwchar/wmemcmp_s.c
@@ -157,4 +157,6 @@ wmemcmp_s (const wchar_t *dest, rsize_t dmax,
 
     return (RCNEGATE(EOK));
 }
-EXPORT_SYMBOL(wmemcmp_s)
+#ifdef __KERNEL__
+EXPORT_SYMBOL(wmemcmp_s);
+#endif /* __KERNEL__ */

--- a/src/ignore_handler_s.c
+++ b/src/ignore_handler_s.c
@@ -65,4 +65,6 @@ ignore_handler_s(const char * restrict msg, void * restrict ptr, errno_t error)
 		       (msg) ? msg : "Null message");
 	return;
 }
-EXPORT_SYMBOL(ignore_handler_s)
+#ifdef __KERNEL__
+EXPORT_SYMBOL(ignore_handler_s);
+#endif /* __KERNEL__ */

--- a/src/io/fopen_s.c
+++ b/src/io/fopen_s.c
@@ -109,6 +109,8 @@ fopen_s(FILE *restrict *restrict streamptr,
 
     return EOK;
 }
-EXPORT_SYMBOL(fopen_s)
+#ifdef __KERNEL__
+EXPORT_SYMBOL(fopen_s);
+#endif /* __KERNEL__ */
 
 #endif /* MINGW_HAS_SECURE_API */

--- a/src/io/fprintf_s.c
+++ b/src/io/fprintf_s.c
@@ -108,4 +108,6 @@ fprintf_s(FILE *restrict stream, const char *restrict fmt, ...)
 
     return ret;
 }
-EXPORT_SYMBOL(fprintf_s)
+#ifdef __KERNEL__
+EXPORT_SYMBOL(fprintf_s);
+#endif /* __KERNEL__ */

--- a/src/io/freopen_s.c
+++ b/src/io/freopen_s.c
@@ -115,6 +115,8 @@ freopen_s(FILE *restrict *restrict newstreamptr,
 
     return EOK;
 }
-EXPORT_SYMBOL(freopen_s)
+#ifdef __KERNEL__
+EXPORT_SYMBOL(freopen_s);
+#endif /* __KERNEL__ */
 
 #endif /* MINGW_HAS_SECURE_API */

--- a/src/io/fscanf_s.c
+++ b/src/io/fscanf_s.c
@@ -133,4 +133,6 @@ fscanf_s(FILE *restrict stream, const char *restrict fmt, ...)
 
     return ret;
 }
-EXPORT_SYMBOL(fscanf_s)
+#ifdef __KERNEL__
+EXPORT_SYMBOL(fscanf_s);
+#endif /* __KERNEL__ */

--- a/src/io/gets_s.c
+++ b/src/io/gets_s.c
@@ -152,4 +152,6 @@ gets_s (char *restrict dest, rsize_t dmax)
 
     return ret;
 }
-EXPORT_SYMBOL(gets_s)
+#ifdef __KERNEL__
+EXPORT_SYMBOL(gets_s);
+#endif /* __KERNEL__ */

--- a/src/io/printf_s.c
+++ b/src/io/printf_s.c
@@ -100,4 +100,6 @@ printf_s(const char *restrict fmt, ...)
 
     return ret;
 }
-EXPORT_SYMBOL(printf_s)
+#ifdef __KERNEL__
+EXPORT_SYMBOL(printf_s);
+#endif /* __KERNEL__ */

--- a/src/io/scanf_s.c
+++ b/src/io/scanf_s.c
@@ -127,4 +127,6 @@ scanf_s(const char *restrict fmt, ...)
 
     return ret;
 }
-EXPORT_SYMBOL(scanf_s)
+#ifdef __KERNEL__
+EXPORT_SYMBOL(scanf_s);
+#endif /* __KERNEL__ */

--- a/src/io/sscanf_s.c
+++ b/src/io/sscanf_s.c
@@ -135,4 +135,6 @@ sscanf_s(const char *restrict buffer, const char *restrict fmt, ...)
 
     return ret;
 }
-EXPORT_SYMBOL(sscanf_s)
+#ifdef __KERNEL__
+EXPORT_SYMBOL(sscanf_s);
+#endif /* __KERNEL__ */

--- a/src/io/tmpfile_s.c
+++ b/src/io/tmpfile_s.c
@@ -106,4 +106,6 @@ tmpfile_s(FILE * restrict * restrict streamptr)
 
     return EOK;
 }
-EXPORT_SYMBOL(tmpfile_s)
+#ifdef __KERNEL__
+EXPORT_SYMBOL(tmpfile_s);
+#endif /* __KERNEL__ */

--- a/src/io/tmpnam_s.c
+++ b/src/io/tmpnam_s.c
@@ -158,4 +158,6 @@ tmpnam_s(char *filename_s, rsize_t maxsize)
         return errno;
     }
 }
-EXPORT_SYMBOL(tmpnam_s)
+#ifdef __KERNEL
+EXPORT_SYMBOL(tmpnam_s);
+#endif /* __KERNEL__ */

--- a/src/io/vfprintf_s.c
+++ b/src/io/vfprintf_s.c
@@ -105,4 +105,6 @@ vfprintf_s(FILE *restrict stream, const char *restrict fmt, va_list ap)
 
     return ret;
 }
-EXPORT_SYMBOL(vfprintf_s)
+#ifdef __KERNEL__
+EXPORT_SYMBOL(vfprintf_s);
+#endif /* __KERNEL__ */

--- a/src/io/vfscanf_s.c
+++ b/src/io/vfscanf_s.c
@@ -130,4 +130,6 @@ vfscanf_s(FILE *restrict stream, const char *restrict fmt, va_list ap)
 
     return ret;
 }
-EXPORT_SYMBOL(vfscanf_s)
+#ifdef __KERNEL__
+EXPORT_SYMBOL(vfscanf_s);
+#endif /* __KERNEL__ */

--- a/src/io/vprintf_s.c
+++ b/src/io/vprintf_s.c
@@ -97,4 +97,6 @@ vprintf_s(const char *restrict fmt, va_list ap)
 
     return ret;
 }
-EXPORT_SYMBOL(vprintf_s)
+#ifdef __KERNEL__
+EXPORT_SYMBOL(vprintf_s);
+#endif /* __KERNEL__  */

--- a/src/io/vscanf_s.c
+++ b/src/io/vscanf_s.c
@@ -124,4 +124,6 @@ vscanf_s(const char *restrict fmt, va_list ap)
 
     return ret;
 }
-EXPORT_SYMBOL(vscanf_s)
+#ifdef __KERNEL__
+EXPORT_SYMBOL(vscanf_s);
+#endif /* __KERNEL__ */

--- a/src/io/vsscanf_s.c
+++ b/src/io/vsscanf_s.c
@@ -132,4 +132,6 @@ vsscanf_s(const char *restrict buffer, const char *restrict fmt, va_list ap)
 
     return ret;
 }
-EXPORT_SYMBOL(vsscanf_s)
+#ifdef __KERNEL__
+EXPORT_SYMBOL(vsscanf_s);
+#endif /* __KERNEL__ */

--- a/src/mem/memcpy_s.c
+++ b/src/mem/memcpy_s.c
@@ -149,6 +149,8 @@ memcpy_s (void * restrict dest, rsize_t dmax, const void * restrict src, rsize_t
 
     return RCNEGATE(EOK);
 }
-EXPORT_SYMBOL(memcpy_s)
+#ifdef __KERNEL__
+EXPORT_SYMBOL(memcpy_s);
+#endif /* __KERNEL__ */
 
 #endif

--- a/src/mem/memmove_s.c
+++ b/src/mem/memmove_s.c
@@ -142,6 +142,8 @@ memmove_s (void *dest, rsize_t dmax, const void *src, rsize_t count)
 
     return (RCNEGATE(EOK));
 }
-EXPORT_SYMBOL(memmove_s)
+#ifdef __KERNEL__
+EXPORT_SYMBOL(memmove_s);
+#endif /* __KERNEL__ */
 
 #endif

--- a/src/mem/memset_s.c
+++ b/src/mem/memset_s.c
@@ -131,6 +131,8 @@ memset_s (void *dest, rsize_t dmax, int value, rsize_t n)
 
     return (RCNEGATE(err));
 }
-EXPORT_SYMBOL(memset_s)
+#ifdef __KERNEL__
+EXPORT_SYMBOL(memset_s);
+#endif /* __KERNEL__ */
 
 #endif

--- a/src/mem/safe_mem_constraint.c
+++ b/src/mem/safe_mem_constraint.c
@@ -75,7 +75,9 @@ set_mem_constraint_handler_s (constraint_handler_t handler)
     }
     return prev_handler;
 }
-EXPORT_SYMBOL(set_mem_constraint_handler_s)
+#ifdef __KERNEL__
+EXPORT_SYMBOL(set_mem_constraint_handler_s);
+#endif /* __KERNEL__ */
 
 
 /**
@@ -98,4 +100,6 @@ invoke_safe_mem_constraint_handler (const char *msg,
         sl_default_handler(msg, ptr, error);
     }
 }
-EXPORT_SYMBOL(invoke_safe_mem_constraint_handler)
+#ifdef __KERNEL__
+EXPORT_SYMBOL(invoke_safe_mem_constraint_handler);
+#endif /* __KERNEL__ */

--- a/src/misc/bsearch_s.c
+++ b/src/misc/bsearch_s.c
@@ -141,4 +141,6 @@ bsearch_s(const void *key, const void *base,
     }
     return NULL;
 }
-EXPORT_SYMBOL(bsearch_s)
+#ifdef __KERNEL__
+EXPORT_SYMBOL(bsearch_s);
+#endif /* __KERNEL__ */

--- a/src/misc/qsort_s.c
+++ b/src/misc/qsort_s.c
@@ -375,6 +375,8 @@ qsort_s(void *base,
 
     return EOK;
 }
-EXPORT_SYMBOL(qsort_s)
+#ifdef __KERNEL__
+EXPORT_SYMBOL(qsort_s);
+#endif /* __KERNEL__ */
 
 #endif /* MINGW_HAS_SECURE_API */

--- a/src/os/asctime_s.c
+++ b/src/os/asctime_s.c
@@ -210,6 +210,8 @@ asctime_s(char *dest, rsize_t dmax, const struct tm *tm)
 
     return EOK;
 }
-EXPORT_SYMBOL(asctime_s)
+#ifdef __KERNEL__
+EXPORT_SYMBOL(asctime_s);
+#endif /* __KERNEL__ */
 
 #endif /* MINGW_HAS_SECURE_API */

--- a/src/os/ctime_s.c
+++ b/src/os/ctime_s.c
@@ -182,4 +182,6 @@ ctime_s(char *dest, rsize_t dmax, const time_t *timer)
 
     return EOK;
 }
-EXPORT_SYMBOL(ctime_s)
+#ifdef __KERNEL__
+EXPORT_SYMBOL(ctime_s);
+#endif /* __KERNEL__ */

--- a/src/os/getenv_s.c
+++ b/src/os/getenv_s.c
@@ -147,4 +147,6 @@ getenv_s(size_t *restrict len, char *restrict dest, rsize_t dmax,
 
     return EOK;
 }
-EXPORT_SYMBOL(getenv_s)
+#ifdef __KERNEL__
+EXPORT_SYMBOL(getenv_s);
+#endif /* __KERNEL__ */

--- a/src/os/gmtime_s.c
+++ b/src/os/gmtime_s.c
@@ -127,6 +127,8 @@ gmtime_s(const time_t *restrict timer, struct tm *restrict dest)
 
     return dest;
 }
-EXPORT_SYMBOL(gmtime_s)
+#ifdef __KERNEL__
+EXPORT_SYMBOL(gmtime_s);
+#endif /* __KERNEL__ */
 
 #endif /* HAVE_MINGW64 */

--- a/src/os/localtime_s.c
+++ b/src/os/localtime_s.c
@@ -128,6 +128,8 @@ localtime_s(const time_t *restrict timer, struct tm *restrict dest)
 
     return dest;
 }
-EXPORT_SYMBOL(localtime_s)
+#ifdef __KERNEL__
+EXPORT_SYMBOL(localtime_s);
+#endif /* __KERNEL__ */
 
 #endif /* HAVE_MINGW64 */

--- a/src/safeclib_private.h
+++ b/src/safeclib_private.h
@@ -38,6 +38,8 @@
 #define NDEBUG
 #endif
 
+#include "config.h"
+
 #ifdef __KERNEL__
 /* linux kernel environment */
 
@@ -59,8 +61,6 @@
 #endif
 
 #else  /* !__KERNEL__ */
-
-#include "config.h"
 
 #if defined(__CYGWIN__) && defined(__x86_64)
 #define HAVE_CYGWIN64

--- a/src/slkm/slkm_init.c
+++ b/src/slkm/slkm_init.c
@@ -31,7 +31,7 @@
 
 #include <linux/module.h>
 #include <linux/kernel.h>
-#include "../safeclib/safeclib_private.h"
+#include "../safeclib_private.h"
 
 #define DRV_NAME        "slk"
 #define DRV_VERSION     "0.0"

--- a/src/str/safe_str_constraint.c
+++ b/src/str/safe_str_constraint.c
@@ -82,7 +82,9 @@ set_str_constraint_handler_s (constraint_handler_t handler)
     }
     return prev_handler;
 }
-EXPORT_SYMBOL(set_str_constraint_handler_s)
+#ifdef __KERNEL__
+EXPORT_SYMBOL(set_str_constraint_handler_s);
+#endif /* __KERNEL__ */
 
 
 /**

--- a/src/str/safe_str_constraint.h
+++ b/src/str/safe_str_constraint.h
@@ -69,6 +69,7 @@ handle_error(char *orig_dest, rsize_t orig_dmax,
     return;
 }
 
+#ifndef SAFECLIB_DISABLE_WCHAR
 /*
  * Safe C Lib internal string routine to consolidate error handling.
  * With SAFECLIB_STR_NULL_SLACK clear the dest wide buffer to eliminate
@@ -90,5 +91,6 @@ handle_werror(wchar_t *orig_dest, rsize_t orig_dmax,
     invoke_safe_str_constraint_handler(err_msg, NULL, err_code);
     return;
 }
+#endif
 
 #endif   /* __SAFE_STR_CONSTRAINT_H__ */

--- a/src/str/snprintf_s.c
+++ b/src/str/snprintf_s.c
@@ -156,6 +156,8 @@ snprintf_s(char * restrict dest, rsize_t dmax, const char * restrict fmt, ...)
 
     return ret;
 }
-EXPORT_SYMBOL(snprintf_s)
+#ifdef __KERNEL__
+EXPORT_SYMBOL(snprintf_s);
+#endif /* __KERNEL__ */
 
 #endif /* SAFECLIB_ENABLE_UNSAFE */

--- a/src/str/sprintf_s.c
+++ b/src/str/sprintf_s.c
@@ -165,4 +165,6 @@ sprintf_s(char * restrict dest, rsize_t dmax, const char * restrict fmt, ...)
 
     return ret;
 }
-EXPORT_SYMBOL(sprintf_s)
+#ifdef __KERNEL__
+EXPORT_SYMBOL(sprintf_s);
+#endif /* __KERNEL__ */

--- a/src/str/strcat_s.c
+++ b/src/str/strcat_s.c
@@ -236,6 +236,8 @@ strcat_s (char *restrict dest, rsize_t dmax, const char *restrict src)
 
     return RCNEGATE(ESNOSPC);
 }
-EXPORT_SYMBOL(strcat_s)
+#ifdef __KERNEL__
+EXPORT_SYMBOL(strcat_s);
+#endif /* __KERNEL__ */
 
 #endif

--- a/src/str/strcpy_s.c
+++ b/src/str/strcpy_s.c
@@ -200,6 +200,8 @@ strcpy_s (char * restrict dest, rsize_t dmax, const char * restrict src)
                  ESNOSPC);
     return RCNEGATE(ESNOSPC);
 }
-EXPORT_SYMBOL(strcpy_s)
+#ifdef __KERNEL__
+EXPORT_SYMBOL(strcpy_s);
+#endif /* __KERNEL__ */
 
 #endif

--- a/src/str/strerror_s.c
+++ b/src/str/strerror_s.c
@@ -129,7 +129,9 @@ strerror_s(char *dest, rsize_t dmax, errno_t errnum)
 
     return EOK;
 }
-EXPORT_SYMBOL(strerror_s)
+#ifdef __KERNEL__
+EXPORT_SYMBOL(strerror_s);
+#endif /* __KERNEL__ */
 
 /**
  * @brief
@@ -163,4 +165,6 @@ strerrorlen_s(errno_t errnum)
         return buf ? strlen(buf) : 0;
     }
 }
-EXPORT_SYMBOL(strerrorlen_s)
+#ifdef __KERNEL__
+EXPORT_SYMBOL(strerrorlen_s);
+#endif /* __KERNEL__ */

--- a/src/str/strncat_s.c
+++ b/src/str/strncat_s.c
@@ -289,4 +289,6 @@ strncat_s (char * restrict dest, rsize_t dmax, const char * restrict src, rsize_
                  ESNOSPC);
     return RCNEGATE(ESNOSPC);
 }
-EXPORT_SYMBOL(strncat_s)
+#ifdef __KERNEL__
+EXPORT_SYMBOL(strncat_s);
+#endif /* __KERNEL__ */

--- a/src/str/strncpy_s.c
+++ b/src/str/strncpy_s.c
@@ -228,4 +228,6 @@ strncpy_s (char * restrict dest, rsize_t dmax, const char * restrict src, rsize_
                  ESNOSPC);
     return RCNEGATE(ESNOSPC);
 }
-EXPORT_SYMBOL(strncpy_s)
+#ifdef __KERNEL__
+EXPORT_SYMBOL(strncpy_s);
+#endif /* __KERNEL__ */

--- a/src/str/strnlen_s.c
+++ b/src/str/strnlen_s.c
@@ -94,4 +94,6 @@ strnlen_s (const char *dest, rsize_t dmax)
 
     return count;
 }
-EXPORT_SYMBOL(strnlen_s)
+#ifdef __KERNEL__
+EXPORT_SYMBOL(strnlen_s);
+#endif /* __KERNEL__ */

--- a/src/str/strtok_s.c
+++ b/src/str/strtok_s.c
@@ -337,6 +337,8 @@ strtok_s(char *restrict dest, rsize_t *restrict dmax,
     *dmax = dlen;
     return (ptoken);
 }
-EXPORT_SYMBOL(strtok_s)
+#ifdef __KERNEL__
+EXPORT_SYMBOL(strtok_s);
+#endif /* __KERNEL__ */
 
 #endif

--- a/src/str/vsnprintf_s.c
+++ b/src/str/vsnprintf_s.c
@@ -145,7 +145,9 @@ vsnprintf_s(char *restrict dest, rsize_t dmax, const char *restrict fmt, va_list
 
     return ret;
 }
-EXPORT_SYMBOL(vsnprintf_s)
+#ifdef __KERNEL__
+EXPORT_SYMBOL(vsnprintf_s);
+#endif /* __KERNEL__ */
 
 #endif /* SAFECLIB_ENABLE_UNSAFE */
 #endif /* MINGW64 */

--- a/src/wchar/fwprintf_s.c
+++ b/src/wchar/fwprintf_s.c
@@ -123,4 +123,6 @@ fwprintf_s(FILE *restrict stream, const wchar_t *restrict fmt, ...)
 
     return ret;
 }
-EXPORT_SYMBOL(fwprintf_s)
+#ifdef __KERNEL__
+EXPORT_SYMBOL(fwprintf_s);
+#endif /* __KERNEL__ */

--- a/src/wchar/fwscanf_s.c
+++ b/src/wchar/fwscanf_s.c
@@ -143,4 +143,6 @@ fwscanf_s(FILE *restrict stream, const wchar_t *restrict fmt, ...)
 
     return ret;
 }
-EXPORT_SYMBOL(fwscanf_s)
+#ifdef __KERNEL__
+EXPORT_SYMBOL(fwscanf_s);
+#endif /* __KERNEL__ */

--- a/src/wchar/mbsrtowcs_s.c
+++ b/src/wchar/mbsrtowcs_s.c
@@ -207,6 +207,8 @@ mbsrtowcs_s (size_t *restrict retval,
 
     return RCNEGATE(rc);
 }
-EXPORT_SYMBOL(mbsrtowcs_s)
+#ifdef __KERNEL__
+EXPORT_SYMBOL(mbsrtowcs_s);
+#endif /* __KERNEL__ */
 
 #endif /* HAVE_WCHAR_H */

--- a/src/wchar/mbstowcs_s.c
+++ b/src/wchar/mbstowcs_s.c
@@ -194,6 +194,8 @@ mbstowcs_s(size_t *restrict retval,
 
     return RCNEGATE(rc);
 }
-EXPORT_SYMBOL(mbstowcs_s)
+#ifdef __KERNEL__
+EXPORT_SYMBOL(mbstowcs_s);
+#endif /* __KERNEL__ */
 
 #endif /* HAVE_WCHAR_H */

--- a/src/wchar/snwprintf_s.c
+++ b/src/wchar/snwprintf_s.c
@@ -222,6 +222,8 @@ snwprintf_s(wchar_t *restrict dest, rsize_t dmax,
 
     return ret;
 }
-EXPORT_SYMBOL(snwprintf_s)
+#ifdef __KERNEL__
+EXPORT_SYMBOL(snwprintf_s);
+#endif /* __KERNEL__ */
 
 #endif /* SAFECLIB_ENABLE_UNSAFE */

--- a/src/wchar/swprintf_s.c
+++ b/src/wchar/swprintf_s.c
@@ -219,4 +219,6 @@ swprintf_s(wchar_t *restrict dest, rsize_t dmax,
 
     return ret;
 }
-EXPORT_SYMBOL(swprintf_s)
+#ifdef __KERNEL__
+EXPORT_SYMBOL(swprintf_s);
+#endif /* __KERNEL__ */

--- a/src/wchar/swscanf_s.c
+++ b/src/wchar/swscanf_s.c
@@ -141,4 +141,6 @@ swscanf_s(const wchar_t *restrict buffer, const wchar_t *restrict fmt, ...)
 
     return ret;
 }
-EXPORT_SYMBOL(swscanf_s)
+#ifdef __KERNEL__
+EXPORT_SYMBOL(swscanf_s);
+#endif /* __KERNEL__ */

--- a/src/wchar/vfwprintf_s.c
+++ b/src/wchar/vfwprintf_s.c
@@ -126,4 +126,6 @@ vfwprintf_s(FILE *restrict stream, const wchar_t *restrict fmt, va_list ap)
 
     return ret;
 }
-EXPORT_SYMBOL(vfwprintf_s)
+#ifdef __KERNEL__
+EXPORT_SYMBOL(vfwprintf_s);
+#endif /* __KERNEL__ */

--- a/src/wchar/vfwscanf_s.c
+++ b/src/wchar/vfwscanf_s.c
@@ -143,4 +143,6 @@ vfwscanf_s(FILE *restrict stream, const wchar_t *restrict fmt, va_list ap)
 
     return ret;
 }
-EXPORT_SYMBOL(vfwscanf_s)
+#ifdef __KERNEL__
+EXPORT_SYMBOL(vfwscanf_s);
+#endif /* __KERNEL__ */

--- a/src/wchar/vsnwprintf_s.c
+++ b/src/wchar/vsnwprintf_s.c
@@ -213,6 +213,8 @@ vsnwprintf_s(wchar_t *restrict dest, rsize_t dmax,
 
     return ret;
 }
-EXPORT_SYMBOL(vsnwprintf_s)
+#ifdef __KERNEL__
+EXPORT_SYMBOL(vsnwprintf_s);
+#endif /* __KERNEL__ */
 
 #endif /* !defined(HAVE_VSNWPRINTF_S) && defined(SAFECLIB_ENABLE_UNSAFE) */

--- a/src/wchar/vswprintf_s.c
+++ b/src/wchar/vswprintf_s.c
@@ -204,4 +204,6 @@ vswprintf_s(wchar_t *restrict dest, rsize_t dmax,
 
     return ret;
 }
-EXPORT_SYMBOL(vswprintf_s)
+#ifdef __KERNEL__
+EXPORT_SYMBOL(vswprintf_s);
+#endif /* __KERNEL__ */

--- a/src/wchar/vswscanf_s.c
+++ b/src/wchar/vswscanf_s.c
@@ -139,4 +139,6 @@ vswscanf_s(const wchar_t *restrict buffer, const wchar_t *restrict fmt,
 
     return ret;
 }
-EXPORT_SYMBOL(vswscanf_s)
+#ifdef __KERNEL__
+EXPORT_SYMBOL(vswscanf_s);
+#endif /* __KERNEL__ */

--- a/src/wchar/vwprintf_s.c
+++ b/src/wchar/vwprintf_s.c
@@ -115,4 +115,6 @@ vwprintf_s(const wchar_t *restrict fmt, va_list ap)
     return ret;
 
 }
-EXPORT_SYMBOL(vwprintf_s)
+#ifdef __KERNEL__
+EXPORT_SYMBOL(vwprintf_s);
+#endif /* __KERNEL__ */

--- a/src/wchar/vwscanf_s.c
+++ b/src/wchar/vwscanf_s.c
@@ -130,4 +130,6 @@ vwscanf_s(const wchar_t *restrict fmt, va_list ap)
 
     return ret;
 }
-EXPORT_SYMBOL(vwscanf_s)
+#ifdef __KERNEL__
+EXPORT_SYMBOL(vwscanf_s);
+#endif /* __KERNEL__ */

--- a/src/wchar/wcrtomb_s.c
+++ b/src/wchar/wcrtomb_s.c
@@ -171,6 +171,8 @@ wcrtomb_s(size_t *restrict retval,
 
     return RCNEGATE(rc);
 }
-EXPORT_SYMBOL(wcrtomb_s)
+#ifdef __KERNEL__
+EXPORT_SYMBOL(wcrtomb_s);
+#endif /* __KERNEL__ */
 
 #endif /* HAVE_WCHAR_H */

--- a/src/wchar/wcscat_s.c
+++ b/src/wchar/wcscat_s.c
@@ -231,6 +231,8 @@ wcscat_s(wchar_t *restrict dest, rsize_t dmax, const wchar_t *restrict src)
 
     return RCNEGATE(ESNOSPC);
 }
-EXPORT_SYMBOL(wcscat_s)
+#ifdef __KERNEL__
+EXPORT_SYMBOL(wcscat_s);
+#endif /* __KERNEL__ */
 
 #endif /* HAVE_WCHAR_H */

--- a/src/wchar/wcscpy_s.c
+++ b/src/wchar/wcscpy_s.c
@@ -199,6 +199,8 @@ wcscpy_s (wchar_t * restrict dest, rsize_t dmax, const wchar_t * restrict src)
                  ESNOSPC);
     return RCNEGATE(ESNOSPC);
 }
-EXPORT_SYMBOL(wcscpy_s)
+#ifdef __KERNEL__
+EXPORT_SYMBOL(wcscpy_s);
+#endif /* __KERNEL__ */
 
 #endif /* HAVE_WCHAR_H */

--- a/src/wchar/wcsncat_s.c
+++ b/src/wchar/wcsncat_s.c
@@ -272,6 +272,8 @@ wcsncat_s(wchar_t *restrict dest, rsize_t dmax,
                  ESNOSPC);
     return RCNEGATE(ESNOSPC);
 }
-EXPORT_SYMBOL(wcsncat_s)
+#ifdef __KERNEL__
+EXPORT_SYMBOL(wcsncat_s);
+#endif /* __KERNEL__ */
 
 #endif /* HAVE_WCHAR_H */

--- a/src/wchar/wcsncpy_s.c
+++ b/src/wchar/wcsncpy_s.c
@@ -227,6 +227,8 @@ wcsncpy_s (wchar_t * restrict dest, rsize_t dmax, const wchar_t * restrict src, 
                  ESNOSPC);
     return RCNEGATE(ESNOSPC);
 }
-EXPORT_SYMBOL(wcsncpy_s)
+#ifdef __KERNEL__
+EXPORT_SYMBOL(wcsncpy_s);
+#endif /* __KERNEL__ */
 
 #endif /* HAVE_WCHAR_H */

--- a/src/wchar/wcsnlen_s.c
+++ b/src/wchar/wcsnlen_s.c
@@ -101,6 +101,8 @@ wcsnlen_s (const wchar_t *dest, rsize_t dmax)
     return dmax ? (rsize_t)(dest - z) : orig_dmax;
 #endif
 }
-EXPORT_SYMBOL(wcsnlen_s)
+#ifdef __KERNEL__
+EXPORT_SYMBOL(wcsnlen_s);
+#endif /* __KERNEL__ */
 
 #endif /* HAVE_WCHAR_H */

--- a/src/wchar/wcsrtombs_s.c
+++ b/src/wchar/wcsrtombs_s.c
@@ -195,6 +195,8 @@ wcsrtombs_s (size_t *restrict retval,
 
     return RCNEGATE(rc);
 }
-EXPORT_SYMBOL(wcsrtombs_s)
+#ifdef __KERNEL__
+EXPORT_SYMBOL(wcsrtombs_s);
+#endif /* __KERNEL__ */
 
 #endif /* HAVE_WCHAR_H */

--- a/src/wchar/wcstok_s.c
+++ b/src/wchar/wcstok_s.c
@@ -340,6 +340,8 @@ wcstok_s(wchar_t *restrict dest, rsize_t *restrict dmax,
     *dmax = dlen;
     return (ptoken);
 }
-EXPORT_SYMBOL(wcstok_s)
+#ifdef __KERNEL__
+EXPORT_SYMBOL(wcstok_s);
+#endif /* __KERNEL__ */
 
 #endif

--- a/src/wchar/wcstombs_s.c
+++ b/src/wchar/wcstombs_s.c
@@ -185,6 +185,8 @@ wcstombs_s (size_t *restrict retval,
 
     return RCNEGATE(rc);
 }
-EXPORT_SYMBOL(wcstombs_s)
+#ifdef __KERNEL__
+EXPORT_SYMBOL(wcstombs_s);
+#endif /* __KERNEL__ */
 
 #endif /* HAVE_WCHAR_H */

--- a/src/wchar/wctomb_s.c
+++ b/src/wchar/wctomb_s.c
@@ -165,6 +165,8 @@ wctomb_s(int *restrict retval,
 
     return RCNEGATE(rc);
 }
-EXPORT_SYMBOL(wctomb_s)
+#ifdef __KERNEL__
+EXPORT_SYMBOL(wctomb_s);
+#endif /* __KERNEL__ */
 
 #endif /* HAVE_WCHAR_H */

--- a/src/wchar/wmemcpy_s.c
+++ b/src/wchar/wmemcpy_s.c
@@ -153,7 +153,9 @@ wmemcpy_s (wchar_t *dest, rsize_t dmax, const wchar_t *src, rsize_t count)
 
     return (RCNEGATE(EOK));
 }
-EXPORT_SYMBOL(wmemcpy_s)
+#ifdef __KERNEL__
+EXPORT_SYMBOL(wmemcpy_s);
+#endif /* __KERNEL__ */
 
 #endif /* TEST_MSVCRT */
 #endif /* HAVE_WCHAR_H */

--- a/src/wchar/wmemmove_s.c
+++ b/src/wchar/wmemmove_s.c
@@ -148,7 +148,9 @@ wmemmove_s (wchar_t *dest, rsize_t dmax, const wchar_t *src, rsize_t count)
 
     return (RCNEGATE(EOK));
 }
-EXPORT_SYMBOL(wmemmove_s)
+#ifdef __KERNEL__
+EXPORT_SYMBOL(wmemmove_s);
+#endif /* __KERNEL__ */
 
 #endif /* TEST_MSVCRT */
 #endif /* HAVE_WCHAR_H */

--- a/src/wchar/wprintf_s.c
+++ b/src/wchar/wprintf_s.c
@@ -121,4 +121,6 @@ wprintf_s(const wchar_t *restrict fmt, ...)
 
     return ret;
 }
-EXPORT_SYMBOL(wprintf_s)
+#ifdef __KERNEL__
+EXPORT_SYMBOL(wprintf_s);
+#endif /* __KERNEL__ */

--- a/src/wchar/wscanf_s.c
+++ b/src/wchar/wscanf_s.c
@@ -128,4 +128,6 @@ wscanf_s(const wchar_t *restrict fmt, ...)
 
     return ret;
 }
-EXPORT_SYMBOL(wscanf_s)
+#ifdef __KERNEL__
+EXPORT_SYMBOL(wscanf_s);
+#endif /* __KERNEL__ */


### PR DESCRIPTION
 - Fix path in Kbuild and slkm_init.c
 - Specify in README that configure must be called with --disable-wchar
to build kernel module (as wchar is not available in kernel space)
 - Include config.h in kernel mode (for restrict define if needed)
 - Fix calls to EXPORT_SYMBOL in all files (missing trailing ;)
 - Do not include time.h in kernel space
 - Do not declare functions that use FILE in kernel space
 - Do not define handle_werror in safe_str_constraint.h if wchar is
disabled