### PR TITLE
Add --disable-doc option

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -104,6 +104,7 @@ LIBTOOL_DISTCLEAN_FILES = \
 	build-tools/test-driver
 DISTCLEANFILES = .version
 
+if ENABLE_DOC
 MAN1_SOURCES = doc/man/man1/check_for_unsafe_apis.1
 dist_man_MANS =
 if HAVE_POD2MAN
@@ -559,6 +560,7 @@ all-local: Doxyfile doc/footer
 clean-local:
 	rm -rf $(builddir)/doc/html
 	rm -rf $(builddir)/doc/man
+endif
 endif
 
 if ENABLE_GCOV

--- a/configure.ac
+++ b/configure.ac
@@ -339,6 +339,16 @@ else
 	AC_MSG_RESULT([no (default)])
 fi
 
+AC_ARG_ENABLE(doc,
+	AS_HELP_STRING([--disable-doc],
+	               [disable documentation @<:@default=no@:>@]),
+	[case "${enableval}" in
+	yes) enable_doc=true ;;
+	no)  enable_doc=false ;;
+	*)   AC_MSG_ERROR([bad value ${enableval} for --enable-doc]) ;;
+	esac], [enable_doc=true])
+AM_CONDITIONAL(ENABLE_DOC, test "x$enable_doc" = "xtrue")
+
 dnl for windows dllimport. checking pic_flag DLL_EXPORT would be better,
 dnl but this is only enabled for the shared objs, and we need it in the config
 dnl for our tests.


### PR DESCRIPTION
This option allows the user to disable man pages even if pod2man and
doxygen programs are found

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>