### PR TITLE
pkg-config: Rework pkg-config support to be usable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ addons:
   apt:
     packages:
       - libtext-diff-perl
+      - pkg-config
 matrix:
   fast_finish: true
   include:

--- a/Makefile.am
+++ b/Makefile.am
@@ -59,7 +59,7 @@ SAFEC_INFRA = \
 	$(top_srcdir)/doc/libc-overview.md     	   \
 	$(top_srcdir)/scripts                      \
 	$(top_srcdir)/.version                     \
-	$(top_srcdir)/safec.pc.in
+	$(top_srcdir)/libsafec.pc.in
 
 SAFEC_GENHEADERS = \
 	$(top_srcdir)/include/safe_config.h.in     \
@@ -80,15 +80,7 @@ EXTRA_DIST = $(SAFEC_INFRA) $(SAFEC_GENHEADERS) $(SAFEC_SLKM)
 
 BUILT_SOURCES = $(top_srcdir)/.version
 
-# Install the generated pkg-config file (.pc) into the expected location for
-# architecture-dependent package configuration information.  Occasionally,
-# pkg-config files are also used for architecture-independent data packages,
-# in which case the correct install location would be $(datadir)/pkgconfig.
-#      pkgconfigdir = $(libdir)/pkgconfig
-#      pkgconfig_DATA = safec-$(SAFEC_API_VERSION).pc
-# We need to be architecture-dependent:
-pcdatadir = $(libdir)/pkgconfig
-pcdata_DATA = safec-$(SAFEC_API_VERSION).pc
+pkgconfig_DATA = libsafec.pc
 
 CLEANFILES = *~
 LIBTOOL_DISTCLEAN_FILES = \

--- a/configure.ac
+++ b/configure.ac
@@ -72,6 +72,9 @@ AM_PROG_AR
                     # it out for now
 LT_INIT
 
+# Initialize pkg-config since we are installing a .pc file
+PKG_INSTALLDIR
+
 
 # Global Variable & Defaults
 # ===============================================
@@ -949,11 +952,8 @@ fi
 # This does the #define/#undef magic
 AC_CONFIG_HEADERS([config.h])
 
-# Override the template file name of the generated .pc file, so that there
-# is no need to rename the template file when the API version changes.
-# This does the @MACRO@ expansion
-AC_CONFIG_FILES([safec-${SAFEC_API_VERSION}.pc:safec.pc.in
-		 include/safe_config.h
+AC_CONFIG_FILES([libsafec.pc
+                 include/safe_config.h
                  include/safe_lib_errno.h
                  include/safe_types.h
                  Makefile

--- a/libsafec.pc.in
+++ b/libsafec.pc.in
@@ -4,9 +4,9 @@ exec_prefix=@exec_prefix@
 libdir=@libdir@
 includedir=@includedir@
 
-Name: @PACKAGE_TARNAME@
+Name: @PACKAGE@
 Description: A safe coding library for C, ref ISO TR24731, C11 Annex K
 Version: @VERSION@
 URL: @PACKAGE_URL@
 Libs: -L${libdir} -lsafec-@SAFEC_API_VERSION@
-Cflags: -I${includedir}/safec-@SAFEC_API_VERSION@ -I${libdir}/safec-@SAFEC_API_VERSION@/include
+Cflags: -I${includedir}/@PACKAGE@

--- a/m4/.gitignore
+++ b/m4/.gitignore
@@ -13,3 +13,4 @@
 /ltsugar.m4
 /ltversion.m4
 /lt~obsolete.m4
+/pkg.m4


### PR DESCRIPTION
Note: This adds an autoreconf-time dependency on pkg-config for pkg.m4.
Also, this renames the pkg-config entry to an invariant libsafec.