### PR TITLE
Fix strcmp_s unit tests by further relaxing the success condition

### DIFF
--- a/tests/test_strcmp_s.c
+++ b/tests/test_strcmp_s.c
@@ -18,9 +18,9 @@
     if (ind != std_ind) {                                                      \
         printf("%s %u  ind=%d  relaxed strcmp()=%d  rc=%d \n", __FUNCTION__,   \
                __LINE__, ind, std_ind, rc);                                    \
-        if (sgn(ind) != std_ind) {                                             \
-            printf("%s %u  sgn(ind)=%d  std_ind=%d  rc=%d \n", __FUNCTION__,   \
-                   __LINE__, sgn(ind), std_ind, rc);                           \
+        if (sgn(ind) != sgn(std_ind)) {                                             \
+            printf("%s %u  sgn(ind)=%d  sgn(std_ind)=%d  rc=%d \n", __FUNCTION__,   \
+                   __LINE__, sgn(ind), sgn(std_ind), rc);                           \
             errs++;                                                            \
         }                                                                      \
     }


### PR DESCRIPTION
strcmp spec only requires it to return <0, 0, or >0. Different
implementations optimize this differently. The value returned
by AArch64 with gcc-8 and glibc-2.28 is neither -1/0/1 nor always
a distance between first differing characters.