### PR TITLE
Define _GNU_SOURCE when needed

### DIFF
--- a/src/extmem/memzero_s.c
+++ b/src/extmem/memzero_s.c
@@ -31,6 +31,8 @@
  *------------------------------------------------------------------
  */
 
+#define _GNU_SOURCE
+
 #ifdef FOR_DOXYGEN
 #include "safe_mem_lib.h"
 #else

--- a/src/io/gets_s.c
+++ b/src/io/gets_s.c
@@ -29,6 +29,8 @@
  *------------------------------------------------------------------
  */
 
+#define _GNU_SOURCE
+
 #ifdef FOR_DOXYGEN
 #include "safe_lib.h"
 #else

--- a/src/os/asctime_s.c
+++ b/src/os/asctime_s.c
@@ -29,6 +29,8 @@
  *------------------------------------------------------------------
  */
 
+#define _GNU_SOURCE
+
 #ifdef FOR_DOXYGEN
 #include "safe_lib.h"
 #else

--- a/src/os/ctime_s.c
+++ b/src/os/ctime_s.c
@@ -29,6 +29,8 @@
  *------------------------------------------------------------------
  */
 
+#define _GNU_SOURCE
+
 #ifdef FOR_DOXYGEN
 #include "safe_lib.h"
 #else

--- a/src/os/gmtime_s.c
+++ b/src/os/gmtime_s.c
@@ -29,6 +29,8 @@
  *------------------------------------------------------------------
  */
 
+#define _GNU_SOURCE
+
 #ifdef FOR_DOXYGEN
 #include "safe_lib.h"
 #else

--- a/src/os/localtime_s.c
+++ b/src/os/localtime_s.c
@@ -29,6 +29,8 @@
  *------------------------------------------------------------------
  */
 
+#define _GNU_SOURCE
+
 #ifdef FOR_DOXYGEN
 #include "safe_lib.h"
 #else


### PR DESCRIPTION
Define _GNU_SOURCE to fix build with musl otherwise we'll got the
following build failures due to localtime_r, strnlen, gmtime_r and
asctime_r being undefined:

os/localtime_s.c:124:12: error: implicit declaration of function 'localtime_r'; did you mean 'localtime_s'? [-Werror=implicit-function-declaration]
     dest = localtime_r(timer, dest);
            ^~~~~~~~~~~

io/gets_s.c:144:32: error: implicit declaration of function 'strnlen'; did you mean 'strlen'? [-Werror=implicit-function-declaration]
         rsize_t len = (rsize_t)strnlen(dest, dmax);
                                ^~~~~~~
                                strlen

An other option would be to define AC_GNU_SOURCE in the configure.ac but
it seems that there is some handling of _GNU_SOURCE in
safeclib_private.h

Fixes:
 - http://autobuild.buildroot.net/results/31a4b647ec0dcd9f517f313ec6c7c8f56da1ee47

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>