### PR TITLE
safeclib_private.h: don't undefine _GNU_SOURCE

### DIFF
--- a/src/safeclib_private.h
+++ b/src/safeclib_private.h
@@ -77,10 +77,12 @@
 #ifdef STDC_HEADERS
 #include <ctype.h>
 #include <stdlib.h>
+#if defined(HAVE_SECURE_GETENV)
 #ifndef _GNU_SOURCE_WAS_DEFINED
 #undef _GNU_SOURCE
 #else
 #undef _GNU_SOURCE_WAS_DEFINED
+#endif
 #endif
 #include <stddef.h>
 #include <stdarg.h>


### PR DESCRIPTION
Commit 3c23c7c4d10d3000c1af8fdeac58ad4b84d6313c added some specific
management of _GNU_SOURCE for secure getenv however some of this
management was not protected with HAVE_SECURE_GETENV block resulting in
_GNU_SOURCE being undefined on some configuration (namely musl on
x86_64)

Fixes:
 - http://autobuild.buildroot.org/results/7923fe7e609a6b2638492350996cc96582cc9193

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>