### PR TITLE
Set HAVE_C99 in safe_config.h

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -387,6 +387,7 @@ AC_PROG_CC_C11
 if test "x$ac_cv_prog_cc_c99" = "xno"; then
    dnl we really should ERROR, lets see how far can come without
    AC_MSG_WARN([This compiler ${CC} has no c99 support])
+   INSERT_SAFECLIB_HAVE_C99="#undef SAFECLIB_HAVE_C99"
 else
    AC_DEFINE([SAFECLIB_HAVE_C99], 1,
         [Defined to 1 when the compiler supports c99, mostly (...) macros])
@@ -394,9 +395,11 @@ else
       AC_MSG_RESULT([added $ac_cv_prog_cc_c99 to CFLAGS])
       AM_CFLAGS="$AM_CFLAGS $ac_cv_prog_cc_c99"
    fi
+   INSERT_SAFECLIB_HAVE_C99="#define SAFECLIB_HAVE_C99 1"
 fi
 dnl AM_CONDITIONAL([SAFECLIB_HAVE_C99], [test "x$ac_cv_prog_cc_c99=no" != "xno"])
 AC_SUBST(SAFECLIB_HAVE_C99)
+AC_SUBST(INSERT_SAFECLIB_HAVE_C99)
 
 if test "x$ac_cv_prog_cc_c11" != "xno"; then
    AC_DEFINE([HAVE_C11], 1,

--- a/configure.ac
+++ b/configure.ac
@@ -388,15 +388,15 @@ if test "x$ac_cv_prog_cc_c99" = "xno"; then
    dnl we really should ERROR, lets see how far can come without
    AC_MSG_WARN([This compiler ${CC} has no c99 support])
 else
-   AC_DEFINE([HAVE_C99], 1,
+   AC_DEFINE([SAFECLIB_HAVE_C99], 1,
         [Defined to 1 when the compiler supports c99, mostly (...) macros])
    if test "x$ac_cv_prog_cc_c99" != "x"; then
       AC_MSG_RESULT([added $ac_cv_prog_cc_c99 to CFLAGS])
       AM_CFLAGS="$AM_CFLAGS $ac_cv_prog_cc_c99"
    fi
 fi
-dnl AM_CONDITIONAL([HAVE_C99], [test "x$ac_cv_prog_cc_c99=no" != "xno"])
-AC_SUBST(HAVE_C99)
+dnl AM_CONDITIONAL([SAFECLIB_HAVE_C99], [test "x$ac_cv_prog_cc_c99=no" != "xno"])
+AC_SUBST(SAFECLIB_HAVE_C99)
 
 if test "x$ac_cv_prog_cc_c11" != "xno"; then
    AC_DEFINE([HAVE_C11], 1,

--- a/include/safe_config.h.in
+++ b/include/safe_config.h.in
@@ -122,6 +122,11 @@ extern "C" {
 @INSERT_ERROR_DMAX@
 
 /*
+ * Set if libsafec3 was compiled with C99 support.
+ */
+@INSERT_SAFECLIB_HAVE_C99@
+
+/*
  * The spec does not call out a maximum len for the strtok src
  * string (the max delims size), so one is defined here.
  */

--- a/include/safe_str_lib.h
+++ b/include/safe_str_lib.h
@@ -153,7 +153,7 @@ char * strtok_s(char *_Str,const char *_Delim,char **_Context); */
 
 /* safe sprintf_s */
 /* now __STDC_WANT_LIB_EXT1__ >= 1 compatible */
-#ifdef HAVE_C99
+#ifdef SAFECLIB_HAVE_C99
 EXTERN int _sprintf_s_chk(char *restrict dest, const rsize_t dmax,
                           const size_t destbos, const char *restrict fmt, ...)
     BOS_CHK(dest) BOS_FMT(fmt);
@@ -171,7 +171,7 @@ EXTERN int _vsprintf_s_chk(char *restrict dest, rsize_t dmax,
     _vsprintf_s_chk(dest, dmax, BOS(dest), fmt, ap)
 
 /* truncating, no ESNOSPC */
-#if defined(HAVE_C99) && !defined(TEST_MSVCRT)
+#if defined(SAFECLIB_HAVE_C99) && !defined(TEST_MSVCRT)
 EXTERN int _snprintf_s_chk(char *restrict dest, rsize_t dmax,
                            const size_t destbos, const char *restrict fmt, ...)
     BOS_CHK(dest) BOS_FMT(fmt);
@@ -621,7 +621,7 @@ wchar_t* wcstok_s(wchar_t *_Str, const wchar_t *_Delim, wchar_t **_Context); */
     _wcstok_s_chk(dest, dmaxp, delim, ptr, BOS(dest))
 #endif
 
-#if defined(HAVE_C99) && !defined(TEST_MSVCRT)
+#if defined(SAFECLIB_HAVE_C99) && !defined(TEST_MSVCRT)
 EXTERN int _swprintf_s_chk(wchar_t *restrict dest, rsize_t dmax,
                            const size_t destbos, const wchar_t *restrict fmt,
                            ...) BOSW_CHK(dest) BOS_FMT(fmt);
@@ -640,7 +640,7 @@ EXTERN int _vswprintf_s_chk(wchar_t *restrict dest, rsize_t dmax,
     _vswprintf_s_chk(dest, dmax, BOS(dest), fmt, ap)
 
 /* truncating, no ESNOSPC */
-#if defined(HAVE_C99) && !defined(TEST_MSVCRT)
+#if defined(SAFECLIB_HAVE_C99) && !defined(TEST_MSVCRT)
 EXTERN int _snwprintf_s_chk(wchar_t *restrict dest, rsize_t dmax,
                             const size_t destbos, const wchar_t *restrict fmt,
                             ...) BOSW_CHK(dest) BOS_FMT(fmt);

--- a/src/io/tmpnam_s.c
+++ b/src/io/tmpnam_s.c
@@ -128,7 +128,7 @@ EXPORT errno_t _tmpnam_s_chk(const char *dest, rsize_t dmax,
         return ESLEMAX;
     }
 
-#if !defined HAVE_C99 && defined HAVE_CXX
+#if !defined SAFECLIB_HAVE_C99 && defined HAVE_CXX
     result = tmpnam(dp);
 #else
 #ifdef __clang

--- a/src/safeclib_private.h
+++ b/src/safeclib_private.h
@@ -49,7 +49,7 @@
 
 #define RCNEGATE(x) (-(x))
 
-#ifndef HAVE_C99
+#ifndef SAFECLIB_HAVE_C99
 #define slprintf
 #define sldebug_printf
 #else
@@ -151,7 +151,7 @@ typedef unsigned long uintptr_t;
 #define RCNEGATE(x) (x)
 
 #define slabort() abort()
-#ifndef HAVE_C99
+#ifndef SAFECLIB_HAVE_C99
 #define slprintf printf
 #define sldebug_printf printf
 #else
@@ -188,7 +188,7 @@ typedef unsigned long uintptr_t;
 #define _UNICODE_MAX 0x10ffff
 
 #ifndef sldebug_printf
-#ifdef HAVE_C99
+#ifdef SAFECLIB_HAVE_C99
 #define sldebug_printf(...)
 #else
 #define sldebug_printf printf
@@ -224,9 +224,9 @@ typedef unsigned long uintptr_t;
 #define GCC_DIAG_RESTORE
 #endif
 
-#if defined(DEBUG) && defined(HAVE_C99) && defined(__KERNEL__)
+#if defined(DEBUG) && defined(SAFECLIB_HAVE_C99) && defined(__KERNEL__)
 #define debug_printf(...) printk(KERN_DEBUG __VA_ARGS__)
-#elif defined(HAVE_C99)
+#elif defined(SAFECLIB_HAVE_C99)
 #define debug_printf(...) fprintf(STDERR, __VA_ARGS__)
 #else
 #define debug_printf printf

--- a/src/str/snprintf_s.c
+++ b/src/str/snprintf_s.c
@@ -91,7 +91,7 @@ any of the arguments corresponding to %s is a null pointer
  *    sprintf_s(), vsnprintf_s(), snwprintf_s()
  */
 
-#ifdef HAVE_C99
+#ifdef SAFECLIB_HAVE_C99
 EXPORT int _snprintf_s_chk(char *restrict dest, rsize_t dmax,
                            const size_t destbos, const char *restrict fmt, ...)
 #else
@@ -102,7 +102,7 @@ EXPORT int snprintf_s(char *restrict dest, rsize_t dmax,
     va_list ap;
     const char *p;
     int ret = -1;
-#ifndef HAVE_C99
+#ifndef SAFECLIB_HAVE_C99
     const size_t destbos = BOS_UNKNOWN;
 #endif
 

--- a/src/str/sprintf_s.c
+++ b/src/str/sprintf_s.c
@@ -97,7 +97,7 @@
  *    vsprintf_s(), snprintf_s()
  */
 
-#ifdef HAVE_C99
+#ifdef SAFECLIB_HAVE_C99
 EXPORT int _sprintf_s_chk(char *restrict dest, const rsize_t dmax,
                           const size_t destbos, const char *restrict fmt, ...)
 #else
@@ -108,7 +108,7 @@ EXPORT int sprintf_s(char *restrict dest, rsize_t dmax,
     int ret = -1;
     va_list ap;
     const char *p;
-#ifndef HAVE_C99
+#ifndef SAFECLIB_HAVE_C99
     const size_t destbos = BOS_UNKNOWN;
 #endif
 

--- a/src/wchar/snwprintf_s.c
+++ b/src/wchar/snwprintf_s.c
@@ -112,7 +112,7 @@ any of the arguments corresponding to %s is a null pointer.
  *    vswprintf_s(), swprintf_s(), vsnprintf_s()
  */
 
-#if defined(HAVE_C99) && !defined(TEST_MSVCRT)
+#if defined(SAFECLIB_HAVE_C99) && !defined(TEST_MSVCRT)
 EXPORT int _snwprintf_s_chk(wchar_t *restrict dest, rsize_t dmax,
                             const size_t destbos, const wchar_t *restrict fmt,
                             ...)
@@ -125,7 +125,7 @@ EXPORT int snwprintf_s(wchar_t *restrict dest, rsize_t dmax,
     wchar_t *p;
     int ret = -1;
     const size_t destsz = dmax * sizeof(wchar_t);
-#if !(defined(HAVE_C99) && !defined(TEST_MSVCRT))
+#if !(defined(SAFECLIB_HAVE_C99) && !defined(TEST_MSVCRT))
     const size_t destbos = BOS_UNKNOWN;
 #endif
 

--- a/src/wchar/swprintf_s.c
+++ b/src/wchar/swprintf_s.c
@@ -109,7 +109,7 @@ any of the arguments corresponding to %s is a null pointer.
  *    vswprintf_s(), snwprintf_s(), vsnprintf_s()
  */
 
-#if defined(HAVE_C99) && !defined(TEST_MSVCRT)
+#if defined(SAFECLIB_HAVE_C99) && !defined(TEST_MSVCRT)
 EXPORT int _swprintf_s_chk(wchar_t *restrict dest, rsize_t dmax,
                            const size_t destbos, const wchar_t *restrict fmt,
                            ...)
@@ -122,7 +122,7 @@ EXPORT int swprintf_s(wchar_t *restrict dest, rsize_t dmax,
     wchar_t *p;
     int ret = -1;
     const size_t destsz = dmax * sizeof(wchar_t);
-#if !(defined(HAVE_C99) && !defined(TEST_MSVCRT))
+#if !(defined(SAFECLIB_HAVE_C99) && !defined(TEST_MSVCRT))
     const size_t destbos = BOS_UNKNOWN;
 #endif
 

--- a/tests/test_private.h
+++ b/tests/test_private.h
@@ -43,7 +43,7 @@
 #include <linux/ctype.h>
 
 #include <linux/string.h>
-#ifdef HAVE_C99
+#ifdef SAFECLIB_HAVE_C99
 #define printf(...) printk(KERN_INFO __VA_ARGS__)
 #endif
 
@@ -215,13 +215,13 @@
 #endif
 
 #ifdef DEBUG
-#if defined(HAVE_C99) && defined(__KERNEL__)
+#if defined(SAFECLIB_HAVE_C99) && defined(__KERNEL__)
 #define debug_printf(...) printk(KERN_DEBUG __VA_ARGS__)
 #else
 #define debug_printf printf
 #endif
 #else
-#ifdef HAVE_C99
+#ifdef SAFECLIB_HAVE_C99
 #define debug_printf(...)
 #else
 #define debug_printf printf
@@ -229,13 +229,13 @@
 #endif
 
 #ifdef XDEBUG
-#if defined(HAVE_C99)
+#if defined(SAFECLIB_HAVE_C99)
 #define xdebug_printf(...) printf(__VA_ARGS__)
 #else
 #define xdebug_printf printf
 #endif
 #else
-#ifdef HAVE_C99
+#ifdef SAFECLIB_HAVE_C99
 #define xdebug_printf(...)
 #else
 #define xdebug_printf printf

--- a/tests/test_snprintf_s.c
+++ b/tests/test_snprintf_s.c
@@ -9,7 +9,7 @@
 #include "test_private.h"
 #include "safe_str_lib.h"
 #if defined(TEST_MSVCRT) && defined(HAVE_SNPRINTF_S)
-#ifdef HAVE_C99
+#ifdef SAFECLIB_HAVE_C99
 #undef snprintf_s
 EXTERN int snprintf_s(char *restrict dest, rsize_t dmax,
                       const char *restrict fmt, ...);
@@ -62,7 +62,7 @@ int test_snprintf_s(void) {
     NEGERR(ESLEMAX)
 
     /* only with c99 __VA_ARGS__ we can pass destbos */
-#ifdef HAVE_C99
+#ifdef SAFECLIB_HAVE_C99
     if (_BOS_KNOWN(str1)) {
         EXPECT_BOS("dest overflow")
         rc = snprintf_s(str1, LEN + 1, "%s", str2);

--- a/tests/test_snwprintf_s.c
+++ b/tests/test_snwprintf_s.c
@@ -47,7 +47,7 @@ int test_snwprintf_s(void) {
     NEGERR(ESZEROL)
 
     /* only with c99 __VA_ARGS__ we can pass destbos */
-#ifdef HAVE_C99
+#ifdef SAFECLIB_HAVE_C99
     if (_BOS_KNOWN(str1)) {
         EXPECT_BOS("dest overflow")
         rc = snwprintf_s(str1, LEN + 1, L"%ls", str2);

--- a/tests/test_sprintf_s.c
+++ b/tests/test_sprintf_s.c
@@ -9,7 +9,7 @@
 #include "test_private.h"
 #include "safe_str_lib.h"
 #if defined(TEST_MSVCRT) && defined(HAVE_SPRINTF_S)
-#ifdef HAVE_C99
+#ifdef SAFECLIB_HAVE_C99
 #undef sprintf_s
 EXTERN int sprintf_s(char *restrict dest, rsize_t dmax,
                      const char *restrict fmt, ...);

--- a/tests/test_swprintf_s.c
+++ b/tests/test_swprintf_s.c
@@ -60,7 +60,7 @@ int main(void) {
     rc = swprintf_s(str1, RSIZE_MAX_STR + 1, L"%ls", str2);
     ERRNO_MSVC(-ESLEMAX, 0);
 
-#if defined HAVE___BUILTIN_OBJECT_SIZE && defined HAVE_C99
+#if defined HAVE___BUILTIN_OBJECT_SIZE && defined SAFECLIB_HAVE_C99
     EXPECT_BOS("dest overflow")
     rc = swprintf_s(str1, LEN + 1, L"%ls", str2);
     ERRNO_MSVC(-EOVERFLOW, 0);


### PR DESCRIPTION
**Rename HAVE_C99 to SAFECLIB_HAVE_C99**

This adds a prefix to make sure this is not conflicting with some other
defines by programs using the header files.

Signed-off-by: Hauke Mehrtens <hauke.mehrtens@intel.com>


**Set SAFECLIB_HAVE_C99 in safe_config.h**

The SAFECLIB_HAVE_C99 preprocessor check is used in public header
and local C files. When an application uses the header files the
SAFECLIB_HAVE_C99 option has to be set to the same option used
when compiling the safeclib. Add this to the configure command.

Without this patch the safeclib was compiled with SAFECLIB_HAVE_C99
and exported the symbol _sprintf_s_chk, but my application used the
header and did not manually set SAFECLIB_HAVE_C99 and then used the
sprintf_s symbol, which is not exported by the shared safeclib.

Signed-off-by: Hauke Mehrtens <hauke.mehrtens@intel.com>