### PR TITLE
Define NDEBUG only if not already defined

### DIFF
--- a/src/safeclib_private.h
+++ b/src/safeclib_private.h
@@ -35,7 +35,9 @@
 #define __SAFECLIB_PRIVATE_H__
 
 #ifndef DEBUG
+#ifndef NDEBUG
 #define NDEBUG
+#endif
 #endif
 
 #include "config.h"


### PR DESCRIPTION
Make it friendlier with other tools (like Conan, that adds NDEBUG to CFLAGS) .