### PR TITLE
configure.ac: add --disable-hardening option

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -383,6 +383,14 @@ AC_ARG_ENABLE(debug-build,
 	esac], [enable_debug_build=false ])
 AM_CONDITIONAL(ENABLE_DEBUG_BUILD, test "x$enable_debug_build" = "xtrue")
 
+AC_ARG_ENABLE(hardening,
+	AS_HELP_STRING([--disable-hardening],
+	               [disable hardening @<:@default=no@:>@]),
+	[case "${enableval}" in
+	yes) enable_hardening=true ;;
+	no)  enable_hardening=false ;;
+	*)   AC_MSG_ERROR([bad value ${enableval} for --enable-hardening]) ;;
+	esac], [enable_hardening=true])
 
 AC_MSG_NOTICE([Check programs])
 # ===============================================
@@ -543,14 +551,17 @@ case $host_os in
        [],[$ax_ccf_err])
     ;;
 esac
-AX_APPEND_COMPILE_FLAGS(
-        [-fstack-protector-strong -fstack-clash-protection -fcf-protection \
-         -fno-strict-aliasing -fno-strict-overflow -fno-delete-null-pointer-checks \
-         -fno-lifetime-dse],
-        [WARN_CFLAGS],[$ax_ccf_err])
-AX_APPEND_LINK_FLAGS(
-        [-fstack-protector-strong -fstack-clash-protection -fcf-protection],
-        [WARN_LDFLAGS],[$ax_ccf_err])
+
+if test "x$enable_hardening" = "xtrue" ; then
+	AX_APPEND_COMPILE_FLAGS(
+	        [-fstack-protector-strong -fstack-clash-protection -fcf-protection \
+	         -fno-strict-aliasing -fno-strict-overflow -fno-delete-null-pointer-checks \
+	         -fno-lifetime-dse],
+	        [WARN_CFLAGS],[$ax_ccf_err])
+	AX_APPEND_LINK_FLAGS(
+	        [-fstack-protector-strong -fstack-clash-protection -fcf-protection],
+	        [WARN_LDFLAGS],[$ax_ccf_err])
+fi
 
 if test x$ax_cv_check_cflags__Wrestrict = xyes; then
    AC_DEFINE([HAVE_WARNING_RESTRICT], 1, [Have -Wrestrict])


### PR DESCRIPTION
Allow the user to disable hardening which is enabled by default since version 02092020 and https://github.com/rurban/safeclib/commit/caa4408eb4a5c767f0474258af3b6ccf444e10aa to avoid the following build failure when the toolchain doesn't support stack-protector:

```
/home/buildroot/autobuild/instance-3/output-1/host/opt/ext-toolchain/m68k-buildroot-uclinux-uclibc/bin/ld.real: ../src/.libs/libsafec-3.6.0.a(safe_mem_constraint.o): in function `handle_mem_bos_chk_warn':
safe_mem_constraint.c:(.text+0x40): undefined reference to `__stack_chk_guard'
```

Fixes:
 - http://autobuild.buildroot.org/results/a481ee2d26a094358b0298617cce691be3077f22

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>