### PR TITLE
Add an option to disable tests

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -34,7 +34,11 @@
 ACLOCAL_AMFLAGS = -I m4 --install ${ACLOCAL_FLAGS}
 
 # Sub-directories to preform recursive make in
-SUBDIRS = src tests
+SUBDIRS = src
+
+if ENABLE_TESTS
+SUBDIRS += tests
+endif
 
 # Library header files
 pkginclude_HEADERS    = \

--- a/configure.ac
+++ b/configure.ac
@@ -360,6 +360,16 @@ AC_ARG_ENABLE(doc,
 	esac], [enable_doc=true])
 AM_CONDITIONAL(ENABLE_DOC, test "x$enable_doc" = "xtrue")
 
+AC_ARG_ENABLE(tests,
+	AS_HELP_STRING([--disable-tests],
+	               [disable tests @<:@default=no@:>@]),
+	[case "${enableval}" in
+	yes) enable_tests=true ;;
+	no)  enable_tests=false ;;
+	*)   AC_MSG_ERROR([bad value ${enableval} for --enable-tests]) ;;
+	esac], [enable_tests=true])
+AM_CONDITIONAL(ENABLE_TESTS, test "x$enable_tests" = "xtrue")
+
 dnl for windows dllimport. checking pic_flag DLL_EXPORT would be better,
 dnl but this is only enabled for the shared objs, and we need it in the config
 dnl for our tests.


### PR DESCRIPTION
Add an option to disable tests which are not always needed (e.g. on embedded systems) and can raise the following build failure on some architectures such as ARM cortex-a9:

```
In file included from perf_memcpy32_s.c:7:
perf_private.h: In function 'rdtsc':
perf_private.h:72:3: error: 'asm' undeclared (first use in this function)
   72 |   asm volatile("mrc p15, 0, %0, c9, c14, 0" : "=r"(pmuseren));
      |   ^~~
```

Fixes:
 - http://autobuild.buildroot.org/results/ceb13c071b1461eb6d73f5940d6b010095127f41

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>