### PR TITLE
safeclib: fix mftb instruction in perf_private.h

### DIFF
--- a/tests/perf_private.h
+++ b/tests/perf_private.h
@@ -104,7 +104,7 @@ static inline clock_t rdtsc() {
     ASM_INLINE volatile (\
       "0:\n"
       "mftbu %0\n"
-      "mftbl %1\n"
+      "mftb %1\n"
       "mftbu %2\n"
       "cmpw %0, %2\n"
       "bne- 0b"


### PR DESCRIPTION
The build fails for `ppc` now, complaining about invalid `mftbl` mnemonics in tests. Correct version is `mftb`, which already refers to “time base lower”.

See, for example: https://www.cs.uaf.edu/2010/fall/cs301/support/ppc/progenv.pdf (p. 70).