### PR TITLE
vsnprintf_s: Increase Buffer Size by 1

### DIFF
--- a/src/str/vsnprintf_s.c
+++ b/src/str/vsnprintf_s.c
@@ -391,7 +391,7 @@ static size_t safec_ftoa(out_fct_type out, const char *funcname, char *buffer,
                          size_t idx, size_t maxlen, double value,
                          unsigned int prec, unsigned int width,
                          unsigned int flags) {
-    char buf[PRINTF_FTOA_BUFFER_SIZE];
+    char buf[PRINTF_FTOA_BUFFER_SIZE + 1]; // Add extra byte for safety
     size_t len = 0U, off = 0U;
     double tmp;
     double diff = 0.0;


### PR DESCRIPTION
It is a buffer overflow warning that GCC 15.2 is catching. The issue is that it's trying to write to `buf[len++]` when len could potentially be 31, which would write to buf[31] in a buffer of size 32 (valid indices 0-31), but the len++ post-increment means it could theoretically write beyond the buffer bounds.

Fixes

../../sources/safec-3.9.1/src/str/vsnprintf_s.c: In function 'safec_ftoa.isra': ../../sources/safec-3.9.1/src/str/vsnprintf_s.c:523:24: error: writing 32 bytes into a region of size 31 [-Werror=stringop-overflow=]
  523 |             buf[len++] = '0';
      |             ~~~~~~~~~~~^~~~~
../../sources/safec-3.9.1/src/str/vsnprintf_s.c:394:10: note: at offset [1, 32] into destination object 'buf' of size 32
  394 |     char buf[PRINTF_FTOA_BUFFER_SIZE];
      |          ^~~
cc1: all warnings being treated as errors