### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,7 @@
 name: Github CI
 on: [push, pull_request]
+permissions:
+  contents: read
 
 #strategy:
 #  matrix:


### PR DESCRIPTION
Potential fix for [https://github.com/rurban/safeclib/security/code-scanning/6](https://github.com/rurban/safeclib/security/code-scanning/6)

In general, the fix is to define an explicit `permissions:` block either at the top level of the workflow (applying to all jobs that don’t override it) or at the job level, granting only the scopes each job actually needs. For a pure CI job that only checks out and reads repository contents, `contents: read` is typically sufficient. Jobs that create GitHub releases need `contents: write` (and sometimes `packages: write` or `pull-requests: write`), but those can be set on those specific jobs.

The minimal, non‑disruptive change that addresses the flagged issue is to add a root‑level `permissions:` block with read‑only access, just below the `on:` declaration. This will apply to all jobs (including the highlighted `aarch64` job), unless individual jobs later define their own `permissions:`. The rest of the workflow’s functionality remains unchanged: checkout and build/test steps will still work with `contents: read`, and release-related actions that require write permissions can be given job-specific overrides later if needed. Concretely, in `.github/workflows/main.yml`, between line 2 (`on: [push, pull_request]`) and line 4 (currently a commented‑out `#strategy:`), add:

```yaml
permissions:
  contents: read
```


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
